### PR TITLE
feat: add OTP sign-in flow

### DIFF
--- a/.agents/skills/done-story/SKILL.md
+++ b/.agents/skills/done-story/SKILL.md
@@ -10,6 +10,9 @@ Context:
 - Read local `AGENTS.md` and `CLAUDE.md` if present.
 - Read the feature `spec.md`, `plan.md`, `tasks.md`, and `tasks/backend.md` under `../hivespace.spec/specs/[feature-name]/`.
 - Read relevant `tasks/config.md`, `tasks/docs-catalog.md`, and `tasks/verification.md` entries when they apply to the completed backend story.
+- Identify any `tasks/verification.md` item with a detail bullet that starts
+  with `User-owned E2E:` and treat it as user-run validation outside this
+  command's executable scope.
 
 Backend checks:
 - New feature work follows CQRS plus Minimal API.
@@ -26,13 +29,24 @@ Backend checks:
 
 Verification:
 - Run the smallest meaningful build/test command for the changed service.
+- Run `.\quality-gate.ps1 -Scope backend:<ServiceName>` for the affected
+  service when coverage applies.
+- Review the reported measured line coverage for the affected service.
+- If coverage is below 90%, add tests and rerun coverage before treating the
+  story as complete.
 - Confirm any generated migration compiles if a migration was added.
 - Confirm no unrelated files were changed.
 - Treat modified `*.json`, `.env`, user-secrets, or other local runtime config as user-owned unless the story explicitly requires validating committed config shape. Do not replace secrets with placeholders, revert local values, or fail the done check solely because user-managed config contains local secret values; instead list those files separately and remind the user that agents must not stage JSON/env secret files.
+- Do not execute, fail, or mark complete any task marked `User-owned E2E:`; list
+  it separately as pending or user-confirmed validation.
 
 Report:
 - List files created and modified.
 - List verification commands and results.
+- Include the affected service coverage percentage and whether it met the 90%
+  target.
 - List modified JSON/env secret-bearing files separately as "user-staged/user-owned config" when present, without treating them as an agent-staged blocker.
+- List `User-owned E2E` tasks separately as pending user validation or
+  user-confirmed complete.
 - If more stories remain, show the next backend story/task group from `tasks/backend.md`, using `tasks.md` for dependency order.
 - Remind the user to run `/wrap-up` in `hivespace.spec` when the full feature is shipped.

--- a/.agents/skills/start-story/SKILL.md
+++ b/.agents/skills/start-story/SKILL.md
@@ -21,10 +21,18 @@ Step 1 - Load context
 - Read `../hivespace.spec/specs/[feature-name]/tasks/backend.md` for the backend implementation tasks.
 - Read relevant `../hivespace.spec/specs/[feature-name]/tasks/config.md`, `tasks/docs-catalog.md`, and `tasks/verification.md` entries when they apply to the selected backend story.
 - Read each affected `../hivespace.spec/services/<service-name>/README.md`.
+- Extract the planned test tasks and scenario coverage expectations for the
+  selected backend story before editing code.
+- Identify any `tasks/verification.md` item with a detail bullet that starts
+  with `User-owned E2E:` and treat it as explicit user-run validation, not
+  implementation scope for this command.
 
 Step 2 - Confirm scope
 - State the story, affected service(s), and exact backend task IDs from `tasks/backend.md` for this session, using `tasks.md` as the high-level task index.
 - State any relevant config, docs/catalog, and verification task IDs from the detailed task files.
+- State any `User-owned E2E` verification task IDs separately as skipped,
+  user-run follow-up items.
+- State the test task IDs and the concrete scenarios they protect.
 - State what will not be implemented in this session.
 - Surface any ambiguity in service ownership, endpoints, events, saga behavior, data ownership, or migration scope before editing.
 
@@ -40,6 +48,8 @@ Before editing, state the concrete repo rules that apply to this story:
 - API rules: use Minimal API endpoints for new feature work, except documented legacy exceptions.
 - Messaging rules: if publishing integration events, use service publishers, publish before save, update contracts/catalog/docs when required.
 - Verification target: name the smallest meaningful build/test/check before implementation starts.
+- Coverage target: name the affected service coverage command and the 90% line
+  coverage expectation before implementation starts.
 
 If any applicable rule is unclear or conflicts with existing code, stop and surface the conflict before editing.
 
@@ -47,19 +57,22 @@ Step 3 - Implement according to the derived contract
 - Follow the implementation contract from Step 2.5 exactly.
 - Prefer documented repo architecture over abbreviated examples in `AGENTS.md`.
 - Keep edits scoped to the selected backend story/task group and any explicitly relevant config, docs/catalog, or verification tasks.
+- Do not execute or mark complete any task marked `User-owned E2E:`.
 - Add or update contracts, endpoints, migrations, consumers, catalogs, and docs only when required by the selected tasks.
 - Before reporting done, verify the contract checklist against the changed files.
 - Verify with the smallest meaningful checks for the changed service, normally `dotnet build` for the affected project and targeted tests if they exist.
 - **TDD ordering**: When the selected backend task group includes test-code tasks (B### tasks that create `*Tests.cs` files), write those test files first. Run `dotnet test --filter [TestClassName]` to confirm the new test is red before writing the implementation. Only then implement the production code to make the test green.
 - **Pre-existing test failure protocol**: When running `dotnet build` or `dotnet test` and a test that existed before this feature's changes fails:
   1. **Identify**: Extract the test class name, test method name, file path, failure message, and the most relevant stack trace line from the output
-  2. **Explain**: State in plain language — which test failed, what user scenario or AC the test protects (read the test name and body), what the expected result was vs. what actually happened
-  3. **Propose**: State whether the fix is in the new implementation code (the test is correct — new code broke existing behavior) or in the test itself (the behavior has intentionally changed); provide the specific change needed
-  4. **STOP and confirm**: Ask the user — "Test `[ClassName.MethodName]` is now failing. It protects: [scenario]. Expected: [expected]. Actual: [actual]. Proposed fix: [change]. Apply? (yes / no / show more)" — do not apply the fix until the user approves
+  2. **Explain**: State in plain language - which test failed, what user scenario or AC the test protects (read the test name and body), what the expected result was vs. what actually happened
+  3. **Propose**: State whether the fix is in the new implementation code (the test is correct - new code broke existing behavior) or in the test itself (the behavior has intentionally changed); provide the specific change needed
+  4. **STOP and confirm**: Ask the user - "Test `[ClassName.MethodName]` is now failing. It protects: [scenario]. Expected: [expected]. Actual: [actual]. Proposed fix: [change]. Apply? (yes / no / show more)" - do not apply the fix until the user approves
   5. **Apply only after approval**: Re-run the affected test after applying; if the user declines, offer to revert the triggering change, skip the task, or mark the failure as accepted risk
+- After implementation, run `.\quality-gate.ps1 -Scope backend:<ServiceName>` for the affected service when coverage is applicable. If coverage is below 90%, add tests and rerun before treating the story as complete.
 
 Step 4 - Report
 - List files changed.
 - Summarize verification.
+- List any skipped `User-owned E2E` tasks as pending user validation.
 - If more backend tasks remain, identify the next story/task group from `tasks/backend.md`.
 - Remind the user to run `/done-story`, then `/wrap-up` in `hivespace.spec` after the full feature ships.

--- a/.agents/skills/verify-story/SKILL.md
+++ b/.agents/skills/verify-story/SKILL.md
@@ -15,6 +15,9 @@ Step 1 - Load context
 - Read `../hivespace.spec/specs/[feature-name]/spec.md`, `plan.md`, `tasks.md`, and `tasks/backend.md`.
 - Read `tasks/config.md`, `tasks/docs-catalog.md`, and `tasks/verification.md` entries that apply to backend/config/docs/catalog/backend verification.
 - Read affected `../hivespace.spec/services/<service-name>/README.md` files named by the plan or backend tasks.
+- Identify any `tasks/verification.md` item with a detail bullet that starts
+  with `User-owned E2E:` and treat it as explicit user-run validation outside
+  this command's executable scope.
 
 Step 2 - Inspect current changes
 - Run `git status --short` and `git diff --name-only` to identify changed, deleted, and untracked files.
@@ -24,22 +27,32 @@ Step 2 - Inspect current changes
 
 Step 3 - Verify task coverage
 - Produce a table for every relevant backend, config, docs/catalog, and verification task with status `Covered`, `Partial`, `Missing`, or `Not Applicable`.
+- Mark `User-owned E2E` tasks as `User-owned` or `Pending user` rather than
+  `Missing` when implementation is otherwise complete.
 - Include concrete evidence for every `Covered` or `Partial` status: file path, symbol/route/type, search result, diff evidence, or verification command.
 - Do not mark a task `Covered` only because an expected file exists; verify behavior, constraints, forbidden behavior, and acceptance criteria.
+- Verify that each planned backend scenario has a matching test or clearly
+  explain the missing coverage.
 - Check public endpoint changes against `shared/api-catalog.md`.
 - Check event/message changes against `shared/event-catalog.md`; confirm reused contracts remain unchanged when tasks require no new event.
 - Check repo rules that commonly regress backend stories: CQRS/Minimal API pattern, service boundaries, outbox for integration events, idempotent consumers, no package `Version=` attributes, and no direct cross-service database reads.
 
 Step 4 - Run verification commands
 - Run the smallest meaningful build/test command for each affected backend service, normally `dotnet build <affected-api-csproj>`.
+- Run `.\quality-gate.ps1 -Scope backend:<ServiceName>` for each affected
+  service when the local environment supports coverage collection.
 - Run full `dotnet build` only when shared libraries, shared authorization, contracts, or multiple services changed.
 - If a command cannot run because of local infrastructure, file locks, or environment issues, report the exact blocker and whether a retry was attempted.
 - Do not run commands that intentionally mutate tracked files.
 
 Step 5 - Report
 - Start with the overall judgment: `Ready`, `Not ready`, or `Blocked`.
+- If only `User-owned E2E` tasks remain, the overall judgment may still be
+  `Ready`, but the pending user validation must be called out explicitly.
 - List critical gaps first, with task IDs and file references.
 - Include the task coverage table.
 - Include verification commands and results.
+- Call out any affected service that is below 90% measured line coverage and
+  identify where additional tests are needed.
 - List unrelated or suspicious changed files separately from expected story files.
 - If gaps remain, recommend running `/start-story` or manual fixes for the specific missing task IDs, then rerun `/verify-story`.

--- a/.claude/commands/done-story.md
+++ b/.claude/commands/done-story.md
@@ -4,6 +4,9 @@ Context:
 - Read local `AGENTS.md` and `CLAUDE.md` if present.
 - Read the feature `spec.md`, `plan.md`, `tasks.md`, and `tasks/backend.md` under `../hivespace.spec/specs/[feature-name]/`.
 - Read relevant `tasks/config.md`, `tasks/docs-catalog.md`, and `tasks/verification.md` entries when they apply to the completed backend story.
+- Identify any `tasks/verification.md` item with a detail bullet that starts
+  with `User-owned E2E:` and treat it as user-run validation outside this
+  command's executable scope.
 
 Backend checks:
 - New feature work follows CQRS plus Minimal API.
@@ -20,13 +23,24 @@ Backend checks:
 
 Verification:
 - Run the smallest meaningful build/test command for the changed service.
+- Run `.\quality-gate.ps1 -Scope backend:<ServiceName>` for the affected
+  service when coverage applies.
+- Review the reported measured line coverage for the affected service.
+- If coverage is below 90%, add tests and rerun coverage before treating the
+  story as complete.
 - Confirm any generated migration compiles if a migration was added.
 - Confirm no unrelated files were changed.
 - Treat modified `*.json`, `.env`, user-secrets, or other local runtime config as user-owned unless the story explicitly requires validating committed config shape. Do not replace secrets with placeholders, revert local values, or fail the done check solely because user-managed config contains local secret values; instead list those files separately and remind the user that agents must not stage JSON/env secret files.
+- Do not execute, fail, or mark complete any task marked `User-owned E2E:`; list
+  it separately as pending or user-confirmed validation.
 
 Report:
 - List files created and modified.
 - List verification commands and results.
+- Include the affected service coverage percentage and whether it met the 90%
+  target.
 - List modified JSON/env secret-bearing files separately as "user-staged/user-owned config" when present, without treating them as an agent-staged blocker.
+- List `User-owned E2E` tasks separately as pending user validation or
+  user-confirmed complete.
 - If more stories remain, show the next backend story/task group from `tasks/backend.md`, using `tasks.md` for dependency order.
 - Remind the user to run `/wrap-up` in `hivespace.spec` when the full feature is shipped.

--- a/.claude/commands/start-story.md
+++ b/.claude/commands/start-story.md
@@ -16,10 +16,18 @@ Step 1 - Load context
 - Read `../hivespace.spec/specs/[feature-name]/tasks/backend.md` for the backend implementation tasks.
 - Read relevant `../hivespace.spec/specs/[feature-name]/tasks/config.md`, `tasks/docs-catalog.md`, and `tasks/verification.md` entries when they apply to the selected backend story.
 - Read each affected `../hivespace.spec/services/<service-name>/README.md`.
+- Extract the planned test tasks and scenario coverage expectations for the
+  selected backend story before editing code.
+- Identify any `tasks/verification.md` item with a detail bullet that starts
+  with `User-owned E2E:` and treat it as explicit user-run validation, not
+  implementation scope for this command.
 
 Step 2 - Confirm scope
 - State the story, affected service(s), and exact backend task IDs from `tasks/backend.md` for this session, using `tasks.md` as the high-level task index.
 - State any relevant config, docs/catalog, and verification task IDs from the detailed task files.
+- State any `User-owned E2E` verification task IDs separately as skipped,
+  user-run follow-up items.
+- State the test task IDs and the concrete scenarios they protect.
 - State what will not be implemented in this session.
 - Surface any ambiguity in service ownership, endpoints, events, saga behavior, data ownership, or migration scope before editing.
 
@@ -35,6 +43,8 @@ Before editing, state the concrete repo rules that apply to this story:
 - API rules: use Minimal API endpoints for new feature work, except documented legacy exceptions.
 - Messaging rules: if publishing integration events, use service publishers, publish before save, update contracts/catalog/docs when required.
 - Verification target: name the smallest meaningful build/test/check before implementation starts.
+- Coverage target: name the affected service coverage command and the 90% line
+  coverage expectation before implementation starts.
 
 If any applicable rule is unclear or conflicts with existing code, stop and surface the conflict before editing.
 
@@ -42,19 +52,22 @@ Step 3 - Implement according to the derived contract
 - Follow the implementation contract from Step 2.5 exactly.
 - Prefer documented repo architecture over abbreviated examples in `AGENTS.md`.
 - Keep edits scoped to the selected backend story/task group and any explicitly relevant config, docs/catalog, or verification tasks.
+- Do not execute or mark complete any task marked `User-owned E2E:`.
 - Add or update contracts, endpoints, migrations, consumers, catalogs, and docs only when required by the selected tasks.
 - Before reporting done, verify the contract checklist against the changed files.
 - Verify with the smallest meaningful checks for the changed service, normally `dotnet build` for the affected project and targeted tests if they exist.
 - **TDD ordering**: When the selected backend task group includes test-code tasks (B### tasks that create `*Tests.cs` files), write those test files first. Run `dotnet test --filter [TestClassName]` to confirm the new test is red before writing the implementation. Only then implement the production code to make the test green.
 - **Pre-existing test failure protocol**: When running `dotnet build` or `dotnet test` and a test that existed before this feature's changes fails:
   1. **Identify**: Extract the test class name, test method name, file path, failure message, and the most relevant stack trace line from the output
-  2. **Explain**: State in plain language — which test failed, what user scenario or AC the test protects (read the test name and body), what the expected result was vs. what actually happened
-  3. **Propose**: State whether the fix is in the new implementation code (the test is correct — new code broke existing behavior) or in the test itself (the behavior has intentionally changed); provide the specific change needed
-  4. **STOP and confirm**: Ask the user — "Test `[ClassName.MethodName]` is now failing. It protects: [scenario]. Expected: [expected]. Actual: [actual]. Proposed fix: [change]. Apply? (yes / no / show more)" — do not apply the fix until the user approves
+  2. **Explain**: State in plain language - which test failed, what user scenario or AC the test protects (read the test name and body), what the expected result was vs. what actually happened
+  3. **Propose**: State whether the fix is in the new implementation code (the test is correct - new code broke existing behavior) or in the test itself (the behavior has intentionally changed); provide the specific change needed
+  4. **STOP and confirm**: Ask the user - "Test `[ClassName.MethodName]` is now failing. It protects: [scenario]. Expected: [expected]. Actual: [actual]. Proposed fix: [change]. Apply? (yes / no / show more)" - do not apply the fix until the user approves
   5. **Apply only after approval**: Re-run the affected test after applying; if the user declines, offer to revert the triggering change, skip the task, or mark the failure as accepted risk
+- After implementation, run `.\quality-gate.ps1 -Scope backend:<ServiceName>` for the affected service when coverage is applicable. If coverage is below 90%, add tests and rerun before treating the story as complete.
 
 Step 4 - Report
 - List files changed.
 - Summarize verification.
+- List any skipped `User-owned E2E` tasks as pending user validation.
 - If more backend tasks remain, identify the next story/task group from `tasks/backend.md`.
 - Remind the user to run `/done-story`, then `/wrap-up` in `hivespace.spec` after the full feature ships.

--- a/.claude/commands/verify-story.md
+++ b/.claude/commands/verify-story.md
@@ -10,6 +10,9 @@ Step 1 - Load context
 - Read `../hivespace.spec/specs/[feature-name]/spec.md`, `plan.md`, `tasks.md`, and `tasks/backend.md`.
 - Read `tasks/config.md`, `tasks/docs-catalog.md`, and `tasks/verification.md` entries that apply to backend/config/docs/catalog/backend verification.
 - Read affected `../hivespace.spec/services/<service-name>/README.md` files named by the plan or backend tasks.
+- Identify any `tasks/verification.md` item with a detail bullet that starts
+  with `User-owned E2E:` and treat it as explicit user-run validation outside
+  this command's executable scope.
 
 Step 2 - Inspect current changes
 - Run `git status --short` and `git diff --name-only` to identify changed, deleted, and untracked files.
@@ -19,22 +22,32 @@ Step 2 - Inspect current changes
 
 Step 3 - Verify task coverage
 - Produce a table for every relevant backend, config, docs/catalog, and verification task with status `Covered`, `Partial`, `Missing`, or `Not Applicable`.
+- Mark `User-owned E2E` tasks as `User-owned` or `Pending user` rather than
+  `Missing` when implementation is otherwise complete.
 - Include concrete evidence for every `Covered` or `Partial` status: file path, symbol/route/type, search result, diff evidence, or verification command.
 - Do not mark a task `Covered` only because an expected file exists; verify behavior, constraints, forbidden behavior, and acceptance criteria.
+- Verify that each planned backend scenario has a matching test or clearly
+  explain the missing coverage.
 - Check public endpoint changes against `shared/api-catalog.md`.
 - Check event/message changes against `shared/event-catalog.md`; confirm reused contracts remain unchanged when tasks require no new event.
 - Check repo rules that commonly regress backend stories: CQRS/Minimal API pattern, service boundaries, outbox for integration events, idempotent consumers, no package `Version=` attributes, and no direct cross-service database reads.
 
 Step 4 - Run verification commands
 - Run the smallest meaningful build/test command for each affected backend service, normally `dotnet build <affected-api-csproj>`.
+- Run `.\quality-gate.ps1 -Scope backend:<ServiceName>` for each affected
+  service when the local environment supports coverage collection.
 - Run full `dotnet build` only when shared libraries, shared authorization, contracts, or multiple services changed.
 - If a command cannot run because of local infrastructure, file locks, or environment issues, report the exact blocker and whether a retry was attempted.
 - Do not run commands that intentionally mutate tracked files.
 
 Step 5 - Report
 - Start with the overall judgment: `Ready`, `Not ready`, or `Blocked`.
+- If only `User-owned E2E` tasks remain, the overall judgment may still be
+  `Ready`, but the pending user validation must be called out explicitly.
 - List critical gaps first, with task IDs and file references.
 - Include the task coverage table.
 - Include verification commands and results.
+- Call out any affected service that is below 90% measured line coverage and
+  identify where additional tests are needed.
 - List unrelated or suspicious changed files separately from expected story files.
 - If gaps remain, recommend running `/start-story` or manual fixes for the specific missing task IDs, then rerun `/verify-story`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,18 @@ This file provides guidance to agents working with code in this repository.
 
 Keep paired Codex and Claude command content semantically equivalent.
 
+Story work is TDD-first and coverage-aware:
+
+- Write the planned test tasks before their paired implementation tasks.
+- After implementation, run backend coverage for the affected service.
+- If the affected measured scope is below 80% line coverage, add tests and rerun
+  coverage before treating the story as complete.
+- Treat any task in `../hivespace.spec/specs/[feature-name]/tasks/verification.md`
+  with a detail bullet that starts with `User-owned E2E:` as explicit but
+  non-executable user work. `/start-story`, `/verify-story`, and `/done-story`
+  must skip those tasks, keep them pending for the user, and never mark them
+  complete automatically.
+
 ## Plan First
 
 - Treat any non-trivial task as architectural work.
@@ -96,7 +108,8 @@ dotnet ef migrations add <Name> --project src/HiveSpace.OrderService/HiveSpace.O
 dotnet ef database update --project src/HiveSpace.OrderService/HiveSpace.OrderService.Infrastructure --startup-project src/HiveSpace.OrderService/HiveSpace.OrderService.Api
 ```
 
-No test projects exist - `dotnet test` returns immediately.
+Run targeted tests whenever they exist, and use `.\quality-gate.ps1 -Scope backend:<ServiceName>`
+after implementation to inspect measured coverage for the affected service.
 
 **Infrastructure requirements**: AppHost starts SQL Server on `localhost:1433` (sa/Passw0rd123!), RabbitMQ on `localhost:5672` (guest/guest), Kafka on `localhost:9092`, Redis on `localhost:6379`, and Azurite on `localhost:10000` / `10001` / `10002`. Frontend dev servers remain outside AppHost v1 and continue using `http://localhost:5000`.
 
@@ -198,6 +211,14 @@ Required flow:
 4. After the PR is open, ask the user to **start a new session** in this repository
 5. In the new session, ask the user to run `/review` to review all current changes
 6. Apply any fixes from the review and push them to the same branch
+
+## Coverage Rule
+
+- Backend stories must review coverage after implementation, not only build/test
+  pass/fail.
+- The target for an affected measured service scope is **80% line coverage**.
+- If coverage is below 80%, add tests for the missing handler, domain, query,
+  consumer, or guard-path behavior and rerun coverage before closing the story.
 
 ## Git Commit Guardrails
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Keep paired Codex and Claude command content semantically equivalent.
 
+Story work is TDD-first and coverage-aware:
+
+- Write the planned test tasks before their paired implementation tasks.
+- After implementation, run backend coverage for the affected service.
+- If the affected measured scope is below 80% line coverage, add tests and rerun
+  coverage before treating the story as complete.
+- Treat any task in `../hivespace.spec/specs/[feature-name]/tasks/verification.md`
+  with a detail bullet that starts with `User-owned E2E:` as explicit but
+  non-executable user work. `/start-story`, `/verify-story`, and `/done-story`
+  must skip those tasks, keep them pending for the user, and never mark them
+  complete automatically.
+
 ## Plan First
 
 - Treat any non-trivial task as architectural work.
@@ -96,7 +108,8 @@ dotnet ef migrations add <Name> --project src/HiveSpace.OrderService/HiveSpace.O
 dotnet ef database update --project src/HiveSpace.OrderService/HiveSpace.OrderService.Infrastructure --startup-project src/HiveSpace.OrderService/HiveSpace.OrderService.Api
 ```
 
-No test projects exist - `dotnet test` returns immediately.
+Run targeted tests whenever they exist, and use `.\quality-gate.ps1 -Scope backend:<ServiceName>`
+after implementation to inspect measured coverage for the affected service.
 
 **Infrastructure requirements**: AppHost starts SQL Server on `localhost:1433` (sa/Passw0rd123!), RabbitMQ on `localhost:5672` (guest/guest), Kafka on `localhost:9092`, Redis on `localhost:6379`, and Azurite on `localhost:10000` / `10001` / `10002`. Frontend dev servers remain outside AppHost v1 and continue using `http://localhost:5000`.
 
@@ -198,6 +211,14 @@ Required flow:
 4. After the PR is open, ask the user to **start a new session** in this repository
 5. In the new session, ask the user to run `/review` to review all current changes
 6. Apply any fixes from the review and push them to the same branch
+
+## Coverage Rule
+
+- Backend stories must review coverage after implementation, not only build/test
+  pass/fail.
+- The target for an affected measured service scope is **80% line coverage**.
+- If coverage is below 80%, add tests for the missing handler, domain, query,
+  consumer, or guard-path behavior and rerun coverage before closing the story.
 
 ## Git Commit Guardrails
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -61,7 +61,7 @@ Generate an HTML report to see per-service coverage before pushing:
 .\coverage.ps1 -Service OrderService
 ```
 
-The `quality-gate.ps1 -Scope backend:OrderService` script reads the Cobertura XML after test run and fails the gate (`coveragePct < 0.80`) with `failureCategory: coverage_below_threshold`.
+The `quality-gate.ps1 -Scope backend:OrderService` script reads the Cobertura XML after test run and fails the gate when measured service coverage is below 80% with `failureCategory: coverage_below_threshold`.
 
 ## TDD Workflow
 
@@ -261,3 +261,6 @@ Generate an HTML coverage report:
 ```
 
 The script deletes stale `TestResults/` and `coverage-report/` directories, runs `dotnet test --collect:"XPlat Code Coverage"`, aggregates all Cobertura XML files, and opens the report in your default browser.
+
+If the reported service coverage is below 80%, treat the story as not complete yet: add tests for the missing measured behavior and rerun the scoped quality gate.
+

--- a/libs/HiveSpace.Infrastructure.Messaging.Shared/Events/Users/UserOtpChallengeRequestedIntegrationEvent.cs
+++ b/libs/HiveSpace.Infrastructure.Messaging.Shared/Events/Users/UserOtpChallengeRequestedIntegrationEvent.cs
@@ -1,0 +1,11 @@
+using HiveSpace.Infrastructure.Messaging.Events;
+
+namespace HiveSpace.Infrastructure.Messaging.Shared.Events.Users;
+
+public record UserOtpChallengeRequestedIntegrationEvent : IntegrationEvent
+{
+    public string RecipientEmail { get; init; } = default!;
+    public string OtpCode { get; init; } = default!;
+    public DateTimeOffset ExpiresAt { get; init; }
+    public string Purpose { get; init; } = default!;
+}

--- a/quality-gate.ps1
+++ b/quality-gate.ps1
@@ -41,7 +41,7 @@ function New-CheckResult {
         [int]$RerunCount,
         [string]$Summary,
         [AllowNull()]
-        [object]$CoveragePct
+        [double]$CoveragePct = $null
     )
 
     [ordered]@{
@@ -303,3 +303,4 @@ $report = [ordered]@{
 }
 
 $report | ConvertTo-Json -Depth 8
+

--- a/src/HiveSpace.ApiGateway/HiveSpace.YarpApiGateway/Middleware/CsrfValidationMiddleware.cs
+++ b/src/HiveSpace.ApiGateway/HiveSpace.YarpApiGateway/Middleware/CsrfValidationMiddleware.cs
@@ -61,6 +61,8 @@ public class CsrfValidationMiddleware(
 
         if (request.Path.Equals("/api/v1/accounts/login", StringComparison.OrdinalIgnoreCase)
             || request.Path.Equals("/api/v1/accounts/register", StringComparison.OrdinalIgnoreCase)
+            || request.Path.Equals("/api/v1/accounts/otp/request", StringComparison.OrdinalIgnoreCase)
+            || request.Path.Equals("/api/v1/accounts/otp/verify", StringComparison.OrdinalIgnoreCase)
             || request.Path.Equals("/api/v1/accounts/email-verification/resend", StringComparison.OrdinalIgnoreCase)
             || request.Path.Equals("/api/v1/accounts/email-verification/verify", StringComparison.OrdinalIgnoreCase))
             return false;

--- a/src/HiveSpace.ApiGateway/HiveSpace.YarpApiGateway/Middleware/SessionForwardingMiddleware.cs
+++ b/src/HiveSpace.ApiGateway/HiveSpace.YarpApiGateway/Middleware/SessionForwardingMiddleware.cs
@@ -94,7 +94,9 @@ public class SessionForwardingMiddleware(
             return true;
 
         return request.Path.Equals("/api/v1/accounts/login", StringComparison.OrdinalIgnoreCase)
-            || request.Path.Equals("/api/v1/accounts/register", StringComparison.OrdinalIgnoreCase);
+            || request.Path.Equals("/api/v1/accounts/register", StringComparison.OrdinalIgnoreCase)
+            || request.Path.Equals("/api/v1/accounts/otp/request", StringComparison.OrdinalIgnoreCase)
+            || request.Path.Equals("/api/v1/accounts/otp/verify", StringComparison.OrdinalIgnoreCase);
     }
 
     private static void RestoreAuthorizationHeader(HttpRequest request, StringValues originalAuthorization)

--- a/src/HiveSpace.AppHost/Program.cs
+++ b/src/HiveSpace.AppHost/Program.cs
@@ -1,4 +1,5 @@
 using HiveSpace.AppHost.Extensions;
+using Microsoft.Extensions.Configuration;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -6,25 +7,21 @@ const string httpLaunchProfile = "http";
 
 var sqlPassword = builder.AddParameter(
     "sqlpassword",
-    () => builder.Configuration["AppHost:SqlServer:Password"]
-          ?? throw new InvalidOperationException("Missing AppHost:SqlServer:Password"),
+    () => RequireNonEmptyConfiguration(builder.Configuration, "AppHost:SqlServer:Password"),
     secret: true);
 
 var rabbitMqUsername = builder.AddParameter(
     "rabbitmqusername",
-    () => builder.Configuration["AppHost:RabbitMq:Username"]
-          ?? throw new InvalidOperationException("Missing AppHost:RabbitMq:Username"));
+    () => RequireNonEmptyConfiguration(builder.Configuration, "AppHost:RabbitMq:Username"));
 
 var rabbitMqPassword = builder.AddParameter(
     "rabbitmqpassword",
-    () => builder.Configuration["AppHost:RabbitMq:Password"]
-          ?? throw new InvalidOperationException("Missing AppHost:RabbitMq:Password"),
+    () => RequireNonEmptyConfiguration(builder.Configuration, "AppHost:RabbitMq:Password"),
     secret: true);
 
 var redisPassword = builder.AddParameter(
     "redispassword",
-    () => builder.Configuration["AppHost:Redis:Password"]
-          ?? throw new InvalidOperationException("Missing AppHost:Redis:Password"),
+    () => RequireNonEmptyConfiguration(builder.Configuration, "AppHost:Redis:Password"),
     secret: true);
 
 var mediaFuncPath = Path.GetFullPath(Path.Combine(
@@ -75,7 +72,8 @@ var queueStorage = storage.AddQueues("azure-queue-storage");
 var identity = builder.AddProject<Projects.HiveSpace_IdentityService_Api>("identity-service", httpLaunchProfile)
     .WithReference(identityDb)
     .WithReference(rabbitMq, "RabbitMq")
-    .WaitFor(identityDb);
+    .WaitFor(identityDb)
+    .WaitFor(rabbitMq);
 
 var identityEndpoint = identity.GetEndpoint(httpLaunchProfile);
 
@@ -83,13 +81,17 @@ var user = builder.AddProject<Projects.HiveSpace_UserService_Api>("user-service"
     .WithReference(userDb)
     .WithReference(rabbitMq, "RabbitMq")
     .WithEnvironment("Authentication__Authority", identityEndpoint)
-    .WaitFor(userDb);
+    .WaitFor(userDb)
+    .WaitFor(rabbitMq)
+    .WaitFor(identity);
 
 var catalog = builder.AddProject<Projects.HiveSpace_CatalogService_Api>("catalog-service", httpLaunchProfile)
     .WithReference(catalogDb)
     .WithReference(rabbitMq, "RabbitMq")
     .WithEnvironment("Authentication__Authority", identityEndpoint)
-    .WaitFor(catalogDb);
+    .WaitFor(catalogDb)
+    .WaitFor(rabbitMq)
+    .WaitFor(identity);
 
 var media = builder.AddProject<Projects.HiveSpace_MediaService_Api>("media-service", httpLaunchProfile)
     .WithReference(rabbitMq, "RabbitMq")
@@ -97,7 +99,10 @@ var media = builder.AddProject<Projects.HiveSpace_MediaService_Api>("media-servi
     .WithReference(blobStorage, "AzureBlobStorage")
     .WithReference(queueStorage, "AzureQueueStorage")
     .WithEnvironment("Authentication__Authority", identityEndpoint)
-    .WaitFor(mediaDb);
+    .WaitFor(mediaDb)
+    .WaitFor(rabbitMq)
+    .WaitFor(storage)
+    .WaitFor(identity);
 
 builder.AddExecutable("media-func", "func", mediaFuncPath, "start", "--port", "7072", "--no-build", "--verbose")
     .WithReference(rabbitMq, "RabbitMq")
@@ -115,21 +120,27 @@ var order = builder.AddProject<Projects.HiveSpace_OrderService_Api>("order-servi
     .WithReference(orderDb)
     .WithReference(rabbitMq, "RabbitMq")
     .WithEnvironment("Authentication__Authority", identityEndpoint)
-    .WaitFor(orderDb);
+    .WaitFor(orderDb)
+    .WaitFor(rabbitMq)
+    .WaitFor(identity);
 
 var payment = builder.AddProject<Projects.HiveSpace_PaymentService_Api>("payment-service", httpLaunchProfile)
     .WithReference(paymentDb)
     .WithReference(rabbitMq, "RabbitMq")
     .WithEnvironment("Authentication__Authority", identityEndpoint)
-    .WaitFor(paymentDb);
+    .WaitFor(paymentDb)
+    .WaitFor(rabbitMq)
+    .WaitFor(identity);
 
 var notification = builder.AddProject<Projects.HiveSpace_NotificationService_Api>("notification-service", httpLaunchProfile)
     .WithReference(notificationDb)
     .WithReference(rabbitMq, "RabbitMq")
     .WithReference(redis, "Redis")
     .WithEnvironment("Authentication__Authority", identityEndpoint)
+    .WaitFor(rabbitMq)
     .WaitFor(redis)
-    .WaitFor(notificationDb);
+    .WaitFor(notificationDb)
+    .WaitFor(identity);
 
 builder.AddProject<Projects.HiveSpace_YarpApiGateway>("api-gateway", httpLaunchProfile)
     .WithReference(identity)
@@ -144,3 +155,12 @@ builder.AddProject<Projects.HiveSpace_YarpApiGateway>("api-gateway", httpLaunchP
     .WithEnvironment("ReverseProxy__Clusters__notification-cluster__Destinations__destination1__Address", notification.GetEndpoint(httpLaunchProfile));
 
 builder.Build().Run();
+
+static string RequireNonEmptyConfiguration(IConfiguration configuration, string key)
+{
+    var value = configuration[key];
+    if (!string.IsNullOrWhiteSpace(value))
+        return value!;
+
+    throw new InvalidOperationException($"Missing or empty {key}");
+}

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Api/Contracts/RequestOtpSignInRequest.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Api/Contracts/RequestOtpSignInRequest.cs
@@ -1,0 +1,3 @@
+namespace HiveSpace.IdentityService.Api.Contracts;
+
+public record RequestOtpSignInRequest(string Email);

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Api/Contracts/VerifyOtpSignInRequest.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Api/Contracts/VerifyOtpSignInRequest.cs
@@ -1,0 +1,3 @@
+namespace HiveSpace.IdentityService.Api.Contracts;
+
+public record VerifyOtpSignInRequest(string ChallengeToken, string Code);

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Api/Endpoints/OtpSignInEndpoints.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Api/Endpoints/OtpSignInEndpoints.cs
@@ -1,0 +1,150 @@
+using HiveSpace.IdentityService.Api.Contracts;
+using HiveSpace.IdentityService.Core.Exceptions;
+using HiveSpace.IdentityService.Core.Features.AccountSessions.Commands.RequestOtpSignIn;
+using HiveSpace.IdentityService.Core.Features.AccountSessions.Commands.VerifyOtpSignIn;
+using HiveSpace.Core.Exceptions;
+using MediatR;
+
+namespace HiveSpace.IdentityService.Api.Endpoints;
+
+internal static class OtpSignInEndpoints
+{
+    public static IEndpointRouteBuilder MapOtpSignInEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/v1/accounts/otp/request", async (
+            RequestOtpSignInRequest request,
+            ISender sender,
+            CancellationToken ct) =>
+        {
+            var response = await sender.Send(new RequestOtpSignInCommand(request.Email), ct);
+            return Results.Ok(response);
+        })
+        .AllowAnonymous()
+        .WithName("RequestOtpSignIn")
+        .WithTags("Accounts")
+        .WithSummary("Request an OTP sign-in code")
+        .WithDescription("Returns a generic success response and sends an OTP email only for eligible buyer or seller accounts.");
+
+        app.MapPost("/api/v1/accounts/otp/verify", async (
+            VerifyOtpSignInRequest request,
+            HttpContext httpContext,
+            IConfiguration configuration,
+            ISender sender,
+            CancellationToken ct) =>
+        {
+            try
+            {
+                var appName = ResolveApp(httpContext.Request, configuration);
+                var returnUrl = ResolveReturnUrl(httpContext.Request, configuration, appName);
+                var response = await sender.Send(new VerifyOtpSignInCommand(
+                    request.ChallengeToken,
+                    request.Code,
+                    appName,
+                    returnUrl), ct);
+
+                return Results.Ok(response);
+            }
+            catch (UnauthorizedException ex) when (TryMapOtpVerifyError(ex, out var error))
+            {
+                return Results.Json(new { error }, statusCode: StatusCodes.Status401Unauthorized);
+            }
+        })
+        .AllowAnonymous()
+        .WithName("VerifyOtpSignIn")
+        .WithTags("Accounts")
+        .WithSummary("Verify an OTP sign-in code")
+        .WithDescription("Verifies an OTP challenge token and code, then establishes the same browser session as password sign-in.");
+
+        return app;
+    }
+
+    private static string ResolveApp(HttpRequest request, IConfiguration configuration)
+    {
+        var appHeader = request.Headers["X-HiveSpace-App"].ToString();
+        if (IsKnownApp(appHeader))
+            return NormalizeApp(appHeader);
+
+        var originCandidates = new[]
+        {
+            request.Headers["Origin"].ToString(),
+            request.Headers["Referer"].ToString()
+        };
+
+        foreach (var candidate in originCandidates)
+        {
+            if (!Uri.TryCreate(candidate, UriKind.Absolute, out var candidateUri))
+                continue;
+
+            foreach (var app in new[] { "seller", "buyer", "admin" })
+            {
+                var configuredOrigin = configuration[$"FrontendRedirects:{app}:Origin"];
+                if (!Uri.TryCreate(configuredOrigin, UriKind.Absolute, out var configuredUri))
+                    continue;
+
+                if (SameOrigin(candidateUri, configuredUri))
+                    return app;
+            }
+        }
+
+        return "buyer";
+    }
+
+    private static string? ResolveReturnUrl(HttpRequest request, IConfiguration configuration, string app)
+    {
+        var candidate = request.Headers["X-HiveSpace-ReturnUrl"].ToString();
+        if (string.IsNullOrWhiteSpace(candidate))
+            return null;
+
+        if (Uri.TryCreate(candidate, UriKind.Relative, out _))
+        {
+            return IsSafeReturnUrl(candidate) ? candidate : null;
+        }
+
+        if (!Uri.TryCreate(candidate, UriKind.Absolute, out var absoluteCandidate))
+            return null;
+
+        var allowedOrigin = configuration[$"FrontendRedirects:{app}:Origin"];
+        if (!Uri.TryCreate(allowedOrigin, UriKind.Absolute, out var allowedUri) || !SameOrigin(absoluteCandidate, allowedUri))
+            return null;
+
+        var relativePath = absoluteCandidate.PathAndQuery;
+        return IsSafeReturnUrl(relativePath) ? relativePath : null;
+    }
+
+    private static bool TryMapOtpVerifyError(UnauthorizedException exception, out string error)
+    {
+        var errorName = exception.ErrorCodeList.FirstOrDefault()?.ErrorCode.Name;
+        error = errorName switch
+        {
+            nameof(IdentityDomainErrorCode.InvalidOrExpiredOtpCode) => "invalid_or_expired_code",
+            nameof(IdentityDomainErrorCode.MaxOtpAttemptsExceeded) => "max_attempts_exceeded",
+            _ => string.Empty
+        };
+
+        return !string.IsNullOrEmpty(error);
+    }
+
+    private static bool SameOrigin(Uri left, Uri right)
+        => string.Equals(left.Scheme, right.Scheme, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(left.Host, right.Host, StringComparison.OrdinalIgnoreCase)
+            && left.Port == right.Port;
+
+    private static bool IsKnownApp(string? app)
+        => !string.IsNullOrWhiteSpace(app)
+            && app.Trim().ToLowerInvariant() is "admin" or "seller" or "buyer";
+
+    private static string NormalizeApp(string app)
+        => app.Trim().ToLowerInvariant();
+
+    private static bool IsSafeReturnUrl(string? returnUrl)
+    {
+        if (string.IsNullOrWhiteSpace(returnUrl))
+            return true;
+
+        if (Uri.TryCreate(returnUrl, UriKind.Relative, out _))
+            return returnUrl.StartsWith('/')
+                && (returnUrl.Length == 1 || returnUrl[1] is not '/' and not '\\');
+
+        return false;
+    }
+}

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Api/Extensions/HostingExtensions.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Api/Extensions/HostingExtensions.cs
@@ -56,6 +56,7 @@ internal static class HostingExtensions
         app.UseAuthorization();
 
         app.MapIdentityEndpoints();
+        app.MapOtpSignInEndpoints();
         app.MapGoogleExternalAuthEndpoints();
         app.MapAdminIdentityEndpoints();
         app.MapDefaultEndpoints();

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Api/Extensions/ServiceCollectionExtensions.cs
@@ -6,10 +6,13 @@ using HiveSpace.IdentityService.Core.Extensions;
 using HiveSpace.IdentityService.Core.DomainModels;
 using HiveSpace.IdentityService.Core.Exceptions;
 using HiveSpace.IdentityService.Core.Features.AccountSessions.Services;
+using HiveSpace.IdentityService.Core.Infrastructure;
 using HiveSpace.IdentityService.Core.Interfaces.Messaging;
+using HiveSpace.IdentityService.Core.Interfaces;
 using HiveSpace.IdentityService.Core.Interfaces.Services;
 using HiveSpace.IdentityService.Core.Infrastructure.Messaging.Publishers;
 using HiveSpace.IdentityService.Core.Persistence;
+using HiveSpace.IdentityService.Core.Persistence.Repositories;
 using HiveSpace.Infrastructure.Messaging.Configurations;
 using HiveSpace.Infrastructure.Messaging.Extensions;
 using HiveSpace.Core.Exceptions;
@@ -193,11 +196,13 @@ internal static class ServiceCollectionExtensions
         services.AddCoreServices();
         services.AddHttpContextAccessor();
         services.AddScoped<IIdentityEventPublisher, IdentityEventPublisher>();
+        services.AddScoped<IOtpChallengeRepository, OtpChallengeRepository>();
         services.AddScoped<IEmailVerificationResendCooldownStore, DistributedEmailVerificationResendCooldownStore>();
         services.AddScoped<ITokenCookieService, TokenCookieService>();
         services.AddScoped<ICsrfTokenService, CsrfTokenService>();
         services.AddScoped<IPendingGoogleLinkStore, PendingGoogleLinkCookieStore>();
         services.AddScoped<IAccountSessionIssuer, AccountSessionIssuer>();
+        services.AddHostedService<OtpChallengeCleanupService>();
 
         return services;
     }

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/DomainModels/Enum/OtpChallengePurpose.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/DomainModels/Enum/OtpChallengePurpose.cs
@@ -1,0 +1,6 @@
+namespace HiveSpace.IdentityService.Core.DomainModels;
+
+public enum OtpChallengePurpose
+{
+    SignIn = 1
+}

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/DomainModels/OtpChallenge.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/DomainModels/OtpChallenge.cs
@@ -1,0 +1,52 @@
+using HiveSpace.Domain.Shared.Entities;
+
+namespace HiveSpace.IdentityService.Core.DomainModels;
+
+public class OtpChallenge : Entity<OtpChallengeId>
+{
+    protected OtpChallenge() { }
+
+    public string EmailNormalized { get; private set; } = default!;
+    public OtpChallengePurpose Purpose { get; private set; }
+    public string ChallengeToken { get; private set; } = default!;
+    public string Code { get; private set; } = default!;
+    public DateTimeOffset ExpiresAt { get; private set; }
+    public DateTimeOffset CanResendAt { get; private set; }
+    public int AttemptCount { get; private set; }
+    public bool IsUsed { get; private set; }
+    public bool IsInvalidated { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+
+    public static OtpChallenge Create(
+        string emailNormalized,
+        OtpChallengePurpose purpose,
+        string challengeToken,
+        string code,
+        DateTimeOffset expiresAt,
+        DateTimeOffset canResendAt)
+    {
+        return new OtpChallenge
+        {
+            Id = OtpChallengeId.New(),
+            EmailNormalized = emailNormalized,
+            Purpose = purpose,
+            ChallengeToken = challengeToken,
+            Code = code,
+            ExpiresAt = expiresAt,
+            CanResendAt = canResendAt,
+            AttemptCount = 0,
+            IsUsed = false,
+            IsInvalidated = false,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    public bool IsActiveAt(DateTimeOffset now)
+        => !IsUsed && !IsInvalidated && ExpiresAt > now;
+
+    public void IncrementAttempt() => AttemptCount++;
+
+    public void MarkUsed() => IsUsed = true;
+
+    public void Invalidate() => IsInvalidated = true;
+}

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/DomainModels/OtpChallengeId.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/DomainModels/OtpChallengeId.cs
@@ -1,0 +1,6 @@
+namespace HiveSpace.IdentityService.Core.DomainModels;
+
+public readonly record struct OtpChallengeId(Guid Value)
+{
+    public static OtpChallengeId New() => new(Guid.NewGuid());
+}

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Exceptions/IdentityDomainErrorCode.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Exceptions/IdentityDomainErrorCode.cs
@@ -25,4 +25,6 @@ public class IdentityDomainErrorCode : DomainErrorCode
     public static readonly IdentityDomainErrorCode PendingGoogleLinkExpired = new(6017, "PendingGoogleLinkExpired", "IDN6017");
     public static readonly IdentityDomainErrorCode EmailVerificationRequired = new(6018, "EmailVerificationRequired", "IDN6018");
     public static readonly IdentityDomainErrorCode PendingEmailVerification = new(6019, "PendingEmailVerification", "IDN6019");
+    public static readonly IdentityDomainErrorCode InvalidOrExpiredOtpCode = new(6020, "InvalidOrExpiredOtpCode", "IDN6020");
+    public static readonly IdentityDomainErrorCode MaxOtpAttemptsExceeded = new(6021, "MaxOtpAttemptsExceeded", "IDN6021");
 }

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Commands/AccountSessionHandlerBase.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Commands/AccountSessionHandlerBase.cs
@@ -1,5 +1,6 @@
 using HiveSpace.IdentityService.Core.Features.AccountSessions.Dtos;
 using HiveSpace.IdentityService.Core.DomainModels;
+using HiveSpace.Domain.Shared.Enumerations;
 using Microsoft.AspNetCore.Identity;
 
 namespace HiveSpace.IdentityService.Core.Features.AccountSessions.Commands;
@@ -37,6 +38,20 @@ internal static class AccountSessionHandlerBase
             roles.Add("Buyer");
 
         return roles;
+    }
+
+    public static async Task<bool> IsOtpSignInEligibleAsync(
+        UserManager<ApplicationUser> userManager,
+        ApplicationUser? user)
+    {
+        if (user is null || !user.EmailConfirmed || user.Status != UserStatus.Active)
+            return false;
+
+        if (await userManager.IsLockedOutAsync(user))
+            return false;
+
+        var roles = await GetRolesAsync(userManager, user);
+        return !roles.Contains("Admin") && !roles.Contains("SystemAdmin");
     }
 
     public static SessionUser ToSessionUser(ApplicationUser user, IReadOnlyCollection<string> roles)

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Commands/RequestOtpSignIn/RequestOtpSignInCommand.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Commands/RequestOtpSignIn/RequestOtpSignInCommand.cs
@@ -1,0 +1,6 @@
+using HiveSpace.Application.Shared.Commands;
+using HiveSpace.IdentityService.Core.Features.AccountSessions.Dtos;
+
+namespace HiveSpace.IdentityService.Core.Features.AccountSessions.Commands.RequestOtpSignIn;
+
+public record RequestOtpSignInCommand(string Email) : ICommand<OtpSignInResponseDto>;

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Commands/RequestOtpSignIn/RequestOtpSignInCommandHandler.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Commands/RequestOtpSignIn/RequestOtpSignInCommandHandler.cs
@@ -70,14 +70,7 @@ public class RequestOtpSignInCommandHandler(
 
     private async Task<bool> IsEligibleAsync(ApplicationUser? user, CancellationToken cancellationToken)
     {
-        if (user is null || !user.EmailConfirmed || user.Status != UserStatus.Active)
-            return false;
-
-        if (await userManager.IsLockedOutAsync(user))
-            return false;
-
-        var roles = await AccountSessionHandlerBase.GetRolesAsync(userManager, user);
-        return !roles.Contains("Admin") && !roles.Contains("SystemAdmin");
+        return await AccountSessionHandlerBase.IsOtpSignInEligibleAsync(userManager, user);
     }
 
     private OtpSignInResponseDto CreateDummyResponse(DateTimeOffset now)
@@ -94,8 +87,6 @@ public class RequestOtpSignInCommandHandler(
 
     private string GenerateCode()
     {
-        var digits = configuration.GetValue("Otp:CodeLengthDigits", 6);
-        var maxExclusive = (int)Math.Pow(10, digits);
-        return Random.Shared.Next(0, maxExclusive).ToString($"D{digits}");
+        return Random.Shared.Next(0, 1_000_000).ToString("D6");
     }
 }

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Commands/RequestOtpSignIn/RequestOtpSignInCommandHandler.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Commands/RequestOtpSignIn/RequestOtpSignInCommandHandler.cs
@@ -1,0 +1,101 @@
+using HiveSpace.Application.Shared.Handlers;
+using HiveSpace.IdentityService.Core.DomainModels;
+using HiveSpace.IdentityService.Core.Features.AccountSessions.Dtos;
+using HiveSpace.IdentityService.Core.Interfaces;
+using HiveSpace.IdentityService.Core.Interfaces.Messaging;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Configuration;
+
+namespace HiveSpace.IdentityService.Core.Features.AccountSessions.Commands.RequestOtpSignIn;
+
+public class RequestOtpSignInCommandHandler(
+    UserManager<ApplicationUser> userManager,
+    IOtpChallengeRepository otpChallengeRepository,
+    IIdentityEventPublisher identityEventPublisher,
+    IConfiguration configuration)
+    : ICommandHandler<RequestOtpSignInCommand, OtpSignInResponseDto>
+{
+    public async Task<OtpSignInResponseDto> Handle(RequestOtpSignInCommand command, CancellationToken cancellationToken)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var normalizedEmail = command.Email.Trim().ToUpperInvariant();
+        var existingChallenge = await otpChallengeRepository.GetLatestActiveByEmailAndPurposeAsync(
+            normalizedEmail,
+            OtpChallengePurpose.SignIn,
+            cancellationToken);
+
+        if (existingChallenge is not null && existingChallenge.CanResendAt > now)
+            return new OtpSignInResponseDto(
+                existingChallenge.ChallengeToken,
+                existingChallenge.ExpiresAt,
+                existingChallenge.CanResendAt);
+
+        var user = await userManager.FindByEmailAsync(command.Email.Trim());
+        if (!await IsEligibleAsync(user, cancellationToken))
+        {
+            if (existingChallenge is not null)
+            {
+                existingChallenge.Invalidate();
+                await otpChallengeRepository.SaveChangesAsync(cancellationToken);
+            }
+
+            return CreateDummyResponse(now);
+        }
+
+        if (existingChallenge is not null)
+            existingChallenge.Invalidate();
+
+        var challenge = OtpChallenge.Create(
+            normalizedEmail,
+            OtpChallengePurpose.SignIn,
+            Guid.NewGuid().ToString("N"),
+            GenerateCode(),
+            now.AddMinutes(GetExpiryMinutes()),
+            now.AddSeconds(GetCooldownSeconds()));
+
+        await otpChallengeRepository.AddAsync(challenge, cancellationToken);
+        await identityEventPublisher.PublishOtpChallengeRequestedAsync(
+            user!,
+            challenge.Code,
+            challenge.ExpiresAt,
+            nameof(OtpChallengePurpose.SignIn),
+            cancellationToken);
+        await otpChallengeRepository.SaveChangesAsync(cancellationToken);
+
+        return new OtpSignInResponseDto(
+            challenge.ChallengeToken,
+            challenge.ExpiresAt,
+            challenge.CanResendAt);
+    }
+
+    private async Task<bool> IsEligibleAsync(ApplicationUser? user, CancellationToken cancellationToken)
+    {
+        if (user is null || !user.EmailConfirmed || user.Status != UserStatus.Active)
+            return false;
+
+        if (await userManager.IsLockedOutAsync(user))
+            return false;
+
+        var roles = await AccountSessionHandlerBase.GetRolesAsync(userManager, user);
+        return !roles.Contains("Admin") && !roles.Contains("SystemAdmin");
+    }
+
+    private OtpSignInResponseDto CreateDummyResponse(DateTimeOffset now)
+        => new(
+            Guid.NewGuid().ToString("N"),
+            now.AddMinutes(GetExpiryMinutes()),
+            now.AddSeconds(GetCooldownSeconds()));
+
+    private int GetExpiryMinutes()
+        => configuration.GetValue("Otp:ExpiryMinutes", 10);
+
+    private int GetCooldownSeconds()
+        => configuration.GetValue("Otp:CooldownSeconds", 60);
+
+    private string GenerateCode()
+    {
+        var digits = configuration.GetValue("Otp:CodeLengthDigits", 6);
+        var maxExclusive = (int)Math.Pow(10, digits);
+        return Random.Shared.Next(0, maxExclusive).ToString($"D{digits}");
+    }
+}

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Commands/RequestOtpSignIn/RequestOtpSignInCommandValidator.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Commands/RequestOtpSignIn/RequestOtpSignInCommandValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+using HiveSpace.Core.Exceptions;
+using HiveSpace.Core.Exceptions.Models;
+using HiveSpace.IdentityService.Core.Exceptions;
+
+namespace HiveSpace.IdentityService.Core.Features.AccountSessions.Commands.RequestOtpSignIn;
+
+public class RequestOtpSignInCommandValidator : AbstractValidator<RequestOtpSignInCommand>
+{
+    public RequestOtpSignInCommandValidator()
+    {
+        RuleFor(c => c.Email)
+            .NotEmpty()
+            .WithState(_ => new Error(CommonErrorCode.Required, nameof(RequestOtpSignInCommand.Email)))
+            .EmailAddress()
+            .WithState(_ => new Error(IdentityDomainErrorCode.InvalidCredentials, nameof(RequestOtpSignInCommand.Email)));
+    }
+}

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Commands/VerifyOtpSignIn/VerifyOtpSignInCommand.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Commands/VerifyOtpSignIn/VerifyOtpSignInCommand.cs
@@ -1,0 +1,10 @@
+using HiveSpace.Application.Shared.Commands;
+using HiveSpace.IdentityService.Core.Features.AccountSessions.Dtos;
+
+namespace HiveSpace.IdentityService.Core.Features.AccountSessions.Commands.VerifyOtpSignIn;
+
+public record VerifyOtpSignInCommand(
+    string ChallengeToken,
+    string Code,
+    string App,
+    string? ReturnUrl) : ICommand<VerifyOtpSignInResponseDto>;

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Commands/VerifyOtpSignIn/VerifyOtpSignInCommandHandler.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Commands/VerifyOtpSignIn/VerifyOtpSignInCommandHandler.cs
@@ -46,6 +46,13 @@ public class VerifyOtpSignInCommandHandler(
             throw InvalidOrExpiredCode();
         }
 
+        if (!await AccountSessionHandlerBase.IsOtpSignInEligibleAsync(userManager, user))
+        {
+            challenge.Invalidate();
+            await otpChallengeRepository.SaveChangesAsync(cancellationToken);
+            throw InvalidOrExpiredCode();
+        }
+
         var roles = await accountSessionIssuer.ValidateCanIssueAsync(user, command.App, cancellationToken);
 
         challenge.MarkUsed();

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Commands/VerifyOtpSignIn/VerifyOtpSignInCommandHandler.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Commands/VerifyOtpSignIn/VerifyOtpSignInCommandHandler.cs
@@ -1,0 +1,84 @@
+using HiveSpace.Application.Shared.Handlers;
+using HiveSpace.Core.Exceptions;
+using HiveSpace.Core.Exceptions.Models;
+using HiveSpace.IdentityService.Core.DomainModels;
+using HiveSpace.IdentityService.Core.Exceptions;
+using HiveSpace.IdentityService.Core.Features.AccountSessions.Dtos;
+using HiveSpace.IdentityService.Core.Interfaces;
+using HiveSpace.IdentityService.Core.Interfaces.Services;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Configuration;
+
+namespace HiveSpace.IdentityService.Core.Features.AccountSessions.Commands.VerifyOtpSignIn;
+
+public class VerifyOtpSignInCommandHandler(
+    UserManager<ApplicationUser> userManager,
+    IOtpChallengeRepository otpChallengeRepository,
+    IAccountSessionIssuer accountSessionIssuer,
+    IConfiguration configuration)
+    : ICommandHandler<VerifyOtpSignInCommand, VerifyOtpSignInResponseDto>
+{
+    public async Task<VerifyOtpSignInResponseDto> Handle(VerifyOtpSignInCommand command, CancellationToken cancellationToken)
+    {
+        var challenge = await otpChallengeRepository.GetActiveByChallengeTokenAsync(command.ChallengeToken, cancellationToken);
+        if (challenge is null || challenge.Purpose != OtpChallengePurpose.SignIn)
+            throw InvalidOrExpiredCode();
+
+        if (!string.Equals(challenge.Code, command.Code, StringComparison.Ordinal))
+        {
+            challenge.IncrementAttempt();
+            if (challenge.AttemptCount >= GetMaxAttempts())
+            {
+                challenge.Invalidate();
+                await otpChallengeRepository.SaveChangesAsync(cancellationToken);
+                throw MaxAttemptsExceeded();
+            }
+
+            await otpChallengeRepository.SaveChangesAsync(cancellationToken);
+            throw InvalidOrExpiredCode();
+        }
+
+        var user = await userManager.FindByEmailAsync(challenge.EmailNormalized);
+        if (user is null)
+        {
+            challenge.Invalidate();
+            await otpChallengeRepository.SaveChangesAsync(cancellationToken);
+            throw InvalidOrExpiredCode();
+        }
+
+        var roles = await accountSessionIssuer.ValidateCanIssueAsync(user, command.App, cancellationToken);
+
+        challenge.MarkUsed();
+        await otpChallengeRepository.SaveChangesAsync(cancellationToken);
+
+        var session = await accountSessionIssuer.IssueAsync(
+            user,
+            command.App,
+            command.ReturnUrl,
+            updateLastLogin: true,
+            roles,
+            cancellationToken);
+
+        return new VerifyOtpSignInResponseDto(SanitizeRedirectUrl(session.RedirectTo));
+    }
+
+    private int GetMaxAttempts()
+        => configuration.GetValue("Otp:MaxAttempts", 5);
+
+    private static UnauthorizedException InvalidOrExpiredCode()
+        => new([new Error(IdentityDomainErrorCode.InvalidOrExpiredOtpCode, nameof(VerifyOtpSignInCommand.Code))]);
+
+    private static UnauthorizedException MaxAttemptsExceeded()
+        => new([new Error(IdentityDomainErrorCode.MaxOtpAttemptsExceeded, nameof(VerifyOtpSignInCommand.Code))]);
+
+    private static string? SanitizeRedirectUrl(string? redirectUrl)
+    {
+        if (string.IsNullOrWhiteSpace(redirectUrl))
+            return null;
+
+        return redirectUrl.StartsWith('/')
+            && (redirectUrl.Length == 1 || redirectUrl[1] is not '/' and not '\\')
+            ? redirectUrl
+            : null;
+    }
+}

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Commands/VerifyOtpSignIn/VerifyOtpSignInCommandValidator.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Commands/VerifyOtpSignIn/VerifyOtpSignInCommandValidator.cs
@@ -1,0 +1,34 @@
+using FluentValidation;
+using HiveSpace.Core.Exceptions;
+using HiveSpace.Core.Exceptions.Models;
+using HiveSpace.IdentityService.Core.Exceptions;
+using HiveSpace.IdentityService.Core.Features.AccountSessions.Commands;
+
+namespace HiveSpace.IdentityService.Core.Features.AccountSessions.Commands.VerifyOtpSignIn;
+
+public class VerifyOtpSignInCommandValidator : AbstractValidator<VerifyOtpSignInCommand>
+{
+    public VerifyOtpSignInCommandValidator()
+    {
+        RuleFor(c => c.ChallengeToken)
+            .NotEmpty()
+            .WithState(_ => new Error(CommonErrorCode.Required, nameof(VerifyOtpSignInCommand.ChallengeToken)));
+
+        RuleFor(c => c.Code)
+            .NotEmpty()
+            .WithState(_ => new Error(CommonErrorCode.Required, nameof(VerifyOtpSignInCommand.Code)))
+            .Length(6)
+            .WithState(_ => new Error(CommonErrorCode.InvalidArgument, nameof(VerifyOtpSignInCommand.Code)))
+            .Matches(@"^\d{6}$")
+            .WithState(_ => new Error(CommonErrorCode.InvalidArgument, nameof(VerifyOtpSignInCommand.Code)));
+
+        RuleFor(c => c.App)
+            .Must(AccountSessionValidation.IsKnownApp)
+            .WithState(_ => new Error(CommonErrorCode.InvalidArgument, nameof(VerifyOtpSignInCommand.App)));
+
+        RuleFor(c => c.ReturnUrl)
+            .Must(AccountSessionValidation.IsSafeReturnUrl)
+            .WithState(_ => new Error(IdentityDomainErrorCode.InvalidReturnUrl, nameof(VerifyOtpSignInCommand.ReturnUrl)))
+            .When(c => !string.IsNullOrWhiteSpace(c.ReturnUrl));
+    }
+}

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Dtos/OtpSignInResponseDto.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Dtos/OtpSignInResponseDto.cs
@@ -1,0 +1,6 @@
+namespace HiveSpace.IdentityService.Core.Features.AccountSessions.Dtos;
+
+public record OtpSignInResponseDto(
+    string ChallengeToken,
+    DateTimeOffset ExpiresAt,
+    DateTimeOffset CanResendAt);

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Dtos/VerifyOtpSignInResponseDto.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Features/AccountSessions/Dtos/VerifyOtpSignInResponseDto.cs
@@ -1,0 +1,3 @@
+namespace HiveSpace.IdentityService.Core.Features.AccountSessions.Dtos;
+
+public record VerifyOtpSignInResponseDto(string? RedirectUrl);

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Infrastructure/Messaging/Publishers/IdentityEventPublisher.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Infrastructure/Messaging/Publishers/IdentityEventPublisher.cs
@@ -48,4 +48,18 @@ public class IdentityEventPublisher(IPublishEndpoint publishEndpoint) : IIdentit
             ToName  = user.FullName ?? user.UserName ?? user.Email!,
             Locale  = locale
         }, cancellationToken);
+
+    public Task PublishOtpChallengeRequestedAsync(
+        ApplicationUser user,
+        string otpCode,
+        DateTimeOffset expiresAt,
+        string purpose,
+        CancellationToken cancellationToken = default)
+        => publishEndpoint.Publish(new UserOtpChallengeRequestedIntegrationEvent
+        {
+            RecipientEmail = user.Email!,
+            OtpCode = otpCode,
+            ExpiresAt = expiresAt,
+            Purpose = purpose
+        }, cancellationToken);
 }

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Infrastructure/OtpChallengeCleanupService.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Infrastructure/OtpChallengeCleanupService.cs
@@ -1,0 +1,57 @@
+using HiveSpace.IdentityService.Core.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace HiveSpace.IdentityService.Core.Infrastructure;
+
+public class OtpChallengeCleanupService(
+    IServiceScopeFactory scopeFactory,
+    IConfiguration configuration,
+    ILogger<OtpChallengeCleanupService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var interval = GetCleanupInterval();
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await CleanupExpiredChallengesAsync(stoppingToken);
+
+            try
+            {
+                await Task.Delay(interval, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+    }
+
+    public async Task<int> CleanupExpiredChallengesAsync(CancellationToken cancellationToken = default)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var repository = scope.ServiceProvider.GetRequiredService<IOtpChallengeRepository>();
+        var cutoff = DateTimeOffset.UtcNow.Add(GetCleanupGrace().Negate());
+        var deletedCount = await repository.DeleteExpiredOlderThanAsync(cutoff, cancellationToken);
+
+        if (deletedCount > 0)
+            logger.LogInformation("Deleted {DeletedCount} expired OTP challenges older than {Cutoff}", deletedCount, cutoff);
+
+        return deletedCount;
+    }
+
+    private TimeSpan GetCleanupInterval()
+    {
+        var configuredHours = configuration.GetValue("Otp:CleanupIntervalHours", 6);
+        return TimeSpan.FromHours(Math.Max(1, configuredHours));
+    }
+
+    private TimeSpan GetCleanupGrace()
+    {
+        var configuredHours = configuration.GetValue("Otp:CleanupGraceHours", 24);
+        return TimeSpan.FromHours(Math.Max(1, configuredHours));
+    }
+}

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Interfaces/IOtpChallengeRepository.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Interfaces/IOtpChallengeRepository.cs
@@ -1,0 +1,12 @@
+using HiveSpace.IdentityService.Core.DomainModels;
+
+namespace HiveSpace.IdentityService.Core.Interfaces;
+
+public interface IOtpChallengeRepository
+{
+    Task<OtpChallenge?> GetActiveByChallengeTokenAsync(string challengeToken, CancellationToken ct = default);
+    Task<OtpChallenge?> GetLatestActiveByEmailAndPurposeAsync(string emailNormalized, OtpChallengePurpose purpose, CancellationToken ct = default);
+    Task<int> DeleteExpiredOlderThanAsync(DateTimeOffset cutoff, CancellationToken ct = default);
+    Task AddAsync(OtpChallenge challenge, CancellationToken ct = default);
+    Task SaveChangesAsync(CancellationToken ct = default);
+}

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Interfaces/Messaging/IIdentityEventPublisher.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Interfaces/Messaging/IIdentityEventPublisher.cs
@@ -21,4 +21,11 @@ public interface IIdentityEventPublisher
         ApplicationUser user,
         Culture locale,
         CancellationToken cancellationToken = default);
+
+    Task PublishOtpChallengeRequestedAsync(
+        ApplicationUser user,
+        string otpCode,
+        DateTimeOffset expiresAt,
+        string purpose,
+        CancellationToken cancellationToken = default);
 }

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Persistence/EntityConfigurations/OtpChallengeConfiguration.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Persistence/EntityConfigurations/OtpChallengeConfiguration.cs
@@ -1,0 +1,51 @@
+using HiveSpace.IdentityService.Core.DomainModels;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace HiveSpace.IdentityService.Core.Persistence.EntityConfigurations;
+
+public class OtpChallengeConfiguration : IEntityTypeConfiguration<OtpChallenge>
+{
+    public void Configure(EntityTypeBuilder<OtpChallenge> builder)
+    {
+        builder.ToTable("otp_challenges");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Id)
+            .HasColumnName("id")
+            .HasConversion(
+                value => value.Value,
+                value => new OtpChallengeId(value));
+
+        builder.Property(x => x.EmailNormalized)
+            .HasColumnName("email_normalized")
+            .HasMaxLength(256)
+            .IsRequired();
+
+        builder.Property(x => x.Purpose)
+            .HasColumnName("purpose")
+            .HasConversion<int>()
+            .IsRequired();
+
+        builder.Property(x => x.ChallengeToken)
+            .HasColumnName("challenge_token")
+            .HasMaxLength(64)
+            .IsRequired();
+
+        builder.Property(x => x.Code)
+            .HasColumnName("code")
+            .HasMaxLength(6)
+            .IsRequired();
+
+        builder.Property(x => x.ExpiresAt).HasColumnName("expires_at").IsRequired();
+        builder.Property(x => x.CanResendAt).HasColumnName("can_resend_at").IsRequired();
+        builder.Property(x => x.AttemptCount).HasColumnName("attempt_count").IsRequired();
+        builder.Property(x => x.IsUsed).HasColumnName("is_used").IsRequired();
+        builder.Property(x => x.IsInvalidated).HasColumnName("is_invalidated").IsRequired();
+        builder.Property(x => x.CreatedAt).HasColumnName("created_at").IsRequired();
+
+        builder.HasIndex(x => x.ChallengeToken).IsUnique();
+        builder.HasIndex(x => new { x.EmailNormalized, x.Purpose });
+    }
+}

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Persistence/IdentityDbContext.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Persistence/IdentityDbContext.cs
@@ -9,6 +9,8 @@ namespace HiveSpace.IdentityService.Core.Persistence;
 public class IdentityDbContext(DbContextOptions<IdentityDbContext> options)
     : IdentityDbContext<ApplicationUser, IdentityRole<Guid>, Guid>(options)
 {
+    public DbSet<OtpChallenge> OtpChallenges => Set<OtpChallenge>();
+
     protected override void OnModelCreating(ModelBuilder builder)
     {
         builder.Ignore<IdentityUserRole<Guid>>();

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Persistence/Migrations/20260622180042_AddOtpChallenge.Designer.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Persistence/Migrations/20260622180042_AddOtpChallenge.Designer.cs
@@ -4,6 +4,7 @@ using HiveSpace.IdentityService.Core.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace HiveSpace.IdentityService.Core.Persistence.Migrations
 {
     [DbContext(typeof(IdentityDbContext))]
-    partial class IdentityDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260622180042_AddOtpChallenge")]
+    partial class AddOtpChallenge
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Persistence/Migrations/20260622180042_AddOtpChallenge.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Persistence/Migrations/20260622180042_AddOtpChallenge.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HiveSpace.IdentityService.Core.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOtpChallenge : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "otp_challenges",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    email_normalized = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    purpose = table.Column<int>(type: "int", nullable: false),
+                    challenge_token = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    code = table.Column<string>(type: "nvarchar(6)", maxLength: 6, nullable: false),
+                    expires_at = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    can_resend_at = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    attempt_count = table.Column<int>(type: "int", nullable: false),
+                    is_used = table.Column<bool>(type: "bit", nullable: false),
+                    is_invalidated = table.Column<bool>(type: "bit", nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_otp_challenges", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_otp_challenges_challenge_token",
+                table: "otp_challenges",
+                column: "challenge_token",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_otp_challenges_email_normalized_purpose",
+                table: "otp_challenges",
+                columns: new[] { "email_normalized", "purpose" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "otp_challenges");
+        }
+    }
+}

--- a/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Persistence/Repositories/OtpChallengeRepository.cs
+++ b/src/HiveSpace.IdentityService/HiveSpace.IdentityService.Core/Persistence/Repositories/OtpChallengeRepository.cs
@@ -1,0 +1,47 @@
+using HiveSpace.IdentityService.Core.DomainModels;
+using HiveSpace.IdentityService.Core.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace HiveSpace.IdentityService.Core.Persistence.Repositories;
+
+public class OtpChallengeRepository(IdentityDbContext dbContext) : IOtpChallengeRepository
+{
+    public Task<OtpChallenge?> GetActiveByChallengeTokenAsync(string challengeToken, CancellationToken ct = default)
+        => dbContext.Set<OtpChallenge>()
+            .OrderByDescending(x => x.CreatedAt)
+            .FirstOrDefaultAsync(
+                x => x.ChallengeToken == challengeToken
+                    && !x.IsUsed
+                    && !x.IsInvalidated
+                    && x.ExpiresAt > DateTimeOffset.UtcNow,
+                ct);
+
+    public Task<OtpChallenge?> GetLatestActiveByEmailAndPurposeAsync(string emailNormalized, OtpChallengePurpose purpose, CancellationToken ct = default)
+        => dbContext.Set<OtpChallenge>()
+            .Where(x => x.EmailNormalized == emailNormalized
+                && x.Purpose == purpose
+                && !x.IsUsed
+                && !x.IsInvalidated
+                && x.ExpiresAt > DateTimeOffset.UtcNow)
+            .OrderByDescending(x => x.CreatedAt)
+            .FirstOrDefaultAsync(ct);
+
+    public async Task<int> DeleteExpiredOlderThanAsync(DateTimeOffset cutoff, CancellationToken ct = default)
+    {
+        var expiredChallenges = await dbContext.Set<OtpChallenge>()
+            .Where(x => x.ExpiresAt <= cutoff)
+            .ToListAsync(ct);
+
+        if (expiredChallenges.Count == 0)
+            return 0;
+
+        dbContext.RemoveRange(expiredChallenges);
+        return await dbContext.SaveChangesAsync(ct);
+    }
+
+    public Task AddAsync(OtpChallenge challenge, CancellationToken ct = default)
+        => dbContext.Set<OtpChallenge>().AddAsync(challenge, ct).AsTask();
+
+    public Task SaveChangesAsync(CancellationToken ct = default)
+        => dbContext.SaveChangesAsync(ct);
+}

--- a/src/HiveSpace.NotificationService/HiveSpace.NotificationService.Api/Consumers/OtpChallengeRequestedConsumer.cs
+++ b/src/HiveSpace.NotificationService/HiveSpace.NotificationService.Api/Consumers/OtpChallengeRequestedConsumer.cs
@@ -1,0 +1,52 @@
+using System.Security.Cryptography;
+using System.Text;
+using HiveSpace.Domain.Shared.Exceptions;
+using HiveSpace.Infrastructure.Messaging.Shared.Events.Users;
+using HiveSpace.NotificationService.Core.Dispatch.Models;
+using HiveSpace.NotificationService.Core.DomainModels;
+using HiveSpace.NotificationService.Core.Exceptions;
+using HiveSpace.NotificationService.Core.Interfaces;
+using MassTransit;
+
+namespace HiveSpace.NotificationService.Api.Consumers;
+
+public class OtpChallengeRequestedConsumer(
+    IDispatchPipeline pipeline,
+    ILogger<OtpChallengeRequestedConsumer> logger) : IConsumer<UserOtpChallengeRequestedIntegrationEvent>
+{
+    public async Task Consume(ConsumeContext<UserOtpChallengeRequestedIntegrationEvent> context)
+        => await ConsumeMessageAsync(context.Message, context.CancellationToken);
+
+    public async Task ConsumeMessageAsync(
+        UserOtpChallengeRequestedIntegrationEvent message,
+        CancellationToken cancellationToken = default)
+    {
+        if (!string.Equals(message.Purpose, "SignIn", StringComparison.Ordinal))
+            throw new InvalidFieldException(NotificationDomainErrorCode.UnsupportedOtpPurpose, nameof(message.Purpose));
+
+        var recipientKey = DeriveRecipientKey(message.RecipientEmail);
+        await pipeline.DispatchAsync(new NotificationRequest
+        {
+            UserId = recipientKey,
+            EventType = NotificationEventType.OtpSignInRequested,
+            IdempotencyKey = $"user.otp.signin:{message.RecipientEmail}:{message.ExpiresAt:yyyyMMddHHmmss}",
+            IsTransactional = true,
+            TemplateData = new Dictionary<string, object>
+            {
+                ["otpCode"] = message.OtpCode,
+                ["expiresAt"] = message.ExpiresAt.ToString("f"),
+                ["_recipientEmail"] = message.RecipientEmail
+            }
+        }, cancellationToken);
+
+        logger.LogInformation("OTP sign-in email dispatched for RecipientEmail={RecipientEmail}", message.RecipientEmail);
+    }
+
+    private static Guid DeriveRecipientKey(string recipientEmail)
+    {
+        var normalized = recipientEmail.Trim().ToUpperInvariant();
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(normalized));
+        var bytes = hash[..16];
+        return new Guid(bytes);
+    }
+}

--- a/src/HiveSpace.NotificationService/HiveSpace.NotificationService.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/HiveSpace.NotificationService/HiveSpace.NotificationService.Api/Extensions/ServiceCollectionExtensions.cs
@@ -128,6 +128,7 @@ internal static class ServiceCollectionExtensions
             cfg.AddConsumer<StoreSyncConsumer>();
             cfg.AddConsumer<EmailVerificationRequestedConsumer>();
             cfg.AddConsumer<EmailVerifiedConsumer>();
+            cfg.AddConsumer<OtpChallengeRequestedConsumer>();
         });
     }
 

--- a/src/HiveSpace.NotificationService/HiveSpace.NotificationService.Core/DomainModels/Enum/NotificationEventType.cs
+++ b/src/HiveSpace.NotificationService/HiveSpace.NotificationService.Core/DomainModels/Enum/NotificationEventType.cs
@@ -14,4 +14,5 @@ public static class NotificationEventType
 
     public const string EmailVerificationRequested = "user.email.verification";
     public const string EmailVerified              = "user.email.verified";
+    public const string OtpSignInRequested         = "user.otp.signin";
 }

--- a/src/HiveSpace.NotificationService/HiveSpace.NotificationService.Core/DomainModels/NotificationEventGroup.cs
+++ b/src/HiveSpace.NotificationService/HiveSpace.NotificationService.Core/DomainModels/NotificationEventGroup.cs
@@ -54,7 +54,8 @@ public static class NotificationEventGroup
         NotificationEventType.LowStockAlert         => Inventory,
 
         NotificationEventType.EmailVerificationRequested
-        or NotificationEventType.EmailVerified          => AccountActivity,
+        or NotificationEventType.EmailVerified
+        or NotificationEventType.OtpSignInRequested    => AccountActivity,
 
         _                                           => Promotions,
     };

--- a/src/HiveSpace.NotificationService/HiveSpace.NotificationService.Core/Exceptions/NotificationDomainErrorCode.cs
+++ b/src/HiveSpace.NotificationService/HiveSpace.NotificationService.Core/Exceptions/NotificationDomainErrorCode.cs
@@ -10,4 +10,5 @@ public class NotificationDomainErrorCode : DomainErrorCode
     public static readonly NotificationDomainErrorCode NotNotificationOwner = new(4002, "NotNotificationOwner", "NTF4002");
     public static readonly NotificationDomainErrorCode InvalidConfiguration  = new(4003, "InvalidConfiguration",  "NTF4003");
     public static readonly NotificationDomainErrorCode InvalidEventGroup     = new(4004, "InvalidEventGroup",     "NTF4004");
+    public static readonly NotificationDomainErrorCode UnsupportedOtpPurpose = new(4005, "UnsupportedOtpPurpose", "NTF4005");
 }

--- a/src/HiveSpace.NotificationService/HiveSpace.NotificationService.Core/Persistence/SeedData/NotificationTemplateSeeder.cs
+++ b/src/HiveSpace.NotificationService/HiveSpace.NotificationService.Core/Persistence/SeedData/NotificationTemplateSeeder.cs
@@ -112,6 +112,26 @@ internal sealed class NotificationTemplateSeeder(
             <p>Thank you for joining HiveSpace!</p>
             """
         ),
+        (
+            NotificationEventType.OtpSignInRequested, NotificationChannel.Email, Culture.Vi,
+            "Ma dang nhap mot lan cua ban",
+            """
+            <p>Xin chao,</p>
+            <p>Ma dang nhap HiveSpace cua ban la <strong>{{ otpCode }}</strong>.</p>
+            <p>Ma co hieu luc den <strong>{{ expiresAt }}</strong>.</p>
+            <p>Neu ban khong yeu cau ma nay, vui long bo qua email.</p>
+            """
+        ),
+        (
+            NotificationEventType.OtpSignInRequested, NotificationChannel.Email, Culture.En,
+            "Your one-time sign-in code",
+            """
+            <p>Hi,</p>
+            <p>Your HiveSpace sign-in code is <strong>{{ otpCode }}</strong>.</p>
+            <p>This code expires at <strong>{{ expiresAt }}</strong>.</p>
+            <p>If you did not request this code, please ignore this email.</p>
+            """
+        ),
     ];
 
     public async Task SeedAsync(CancellationToken ct = default)

--- a/tests/HiveSpace.IdentityService.Tests/Application/Session/OtpChallengeCleanupServiceTests.cs
+++ b/tests/HiveSpace.IdentityService.Tests/Application/Session/OtpChallengeCleanupServiceTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using HiveSpace.IdentityService.Core.DomainModels;
+using HiveSpace.IdentityService.Core.Infrastructure;
+using HiveSpace.IdentityService.Core.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace HiveSpace.IdentityService.Tests.Application.Session;
+
+public class OtpChallengeCleanupServiceTests
+{
+    [Fact]
+    public async Task CleanupExpiredChallengesAsync_DeletesOnlyRowsPastGraceCutoff()
+    {
+        var repository = new RecordingOtpChallengeRepository();
+        var services = new ServiceCollection()
+            .AddScoped<IOtpChallengeRepository>(_ => repository)
+            .BuildServiceProvider();
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Otp:CleanupGraceHours"] = "24",
+                ["Otp:CleanupIntervalHours"] = "6"
+            })
+            .Build();
+
+        var service = new OtpChallengeCleanupService(
+            services.GetRequiredService<IServiceScopeFactory>(),
+            configuration,
+            NullLogger<OtpChallengeCleanupService>.Instance);
+
+        var deletedCount = await service.CleanupExpiredChallengesAsync();
+
+        deletedCount.Should().Be(3);
+        repository.DeleteExpiredCalled.Should().BeTrue();
+        repository.LastCutoff.Should().NotBeNull();
+        repository.LastCutoff.Should().BeBefore(DateTimeOffset.UtcNow.AddHours(-23));
+        repository.LastCutoff.Should().BeAfter(DateTimeOffset.UtcNow.AddHours(-25));
+    }
+
+    private sealed class RecordingOtpChallengeRepository : IOtpChallengeRepository
+    {
+        public bool DeleteExpiredCalled { get; private set; }
+        public DateTimeOffset? LastCutoff { get; private set; }
+
+        public Task<OtpChallenge?> GetActiveByChallengeTokenAsync(string challengeToken, CancellationToken ct = default)
+            => Task.FromResult<OtpChallenge?>(null);
+
+        public Task<OtpChallenge?> GetLatestActiveByEmailAndPurposeAsync(string emailNormalized, OtpChallengePurpose purpose, CancellationToken ct = default)
+            => Task.FromResult<OtpChallenge?>(null);
+
+        public Task<int> DeleteExpiredOlderThanAsync(DateTimeOffset cutoff, CancellationToken ct = default)
+        {
+            DeleteExpiredCalled = true;
+            LastCutoff = cutoff;
+            return Task.FromResult(3);
+        }
+
+        public Task AddAsync(OtpChallenge challenge, CancellationToken ct = default)
+            => Task.CompletedTask;
+
+        public Task SaveChangesAsync(CancellationToken ct = default)
+            => Task.CompletedTask;
+    }
+}

--- a/tests/HiveSpace.IdentityService.Tests/Application/Session/RequestOtpSignInCommandHandlerTests.cs
+++ b/tests/HiveSpace.IdentityService.Tests/Application/Session/RequestOtpSignInCommandHandlerTests.cs
@@ -1,0 +1,269 @@
+using FluentAssertions;
+using HiveSpace.IdentityService.Core.DomainModels;
+using HiveSpace.IdentityService.Core.Features.AccountSessions.Commands.RequestOtpSignIn;
+using HiveSpace.IdentityService.Core.Interfaces.Messaging;
+using HiveSpace.IdentityService.Core.Persistence;
+using HiveSpace.Infrastructure.Messaging.Shared.Events.Users;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+using HiveSpace.IdentityService.Core.Persistence.Repositories;
+
+namespace HiveSpace.IdentityService.Tests.Application.Session;
+
+public class RequestOtpSignInCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_EligibleBuyerOrSeller_PersistsChallengeAndPublishesEvent()
+    {
+        await using var dbContext = CreateDbContext();
+        var userManager = CreateUserManager(dbContext);
+        var user = CreateUser("buyer-otp@hivespace.local", "Buyer", UserStatus.Active, emailConfirmed: true);
+        dbContext.Users.Add(user);
+        await dbContext.SaveChangesAsync();
+
+        var publisher = new RecordingIdentityEventPublisher();
+        var handler = new RequestOtpSignInCommandHandler(
+            userManager,
+            new OtpChallengeRepository(dbContext),
+            publisher,
+            CreateConfiguration());
+
+        var response = await handler.Handle(
+            new RequestOtpSignInCommand("buyer-otp@hivespace.local"),
+            CancellationToken.None);
+
+        var challenge = await dbContext.Set<OtpChallenge>().SingleAsync();
+        response.ChallengeToken.Should().Be(challenge.ChallengeToken);
+        response.ExpiresAt.Should().Be(challenge.ExpiresAt);
+        response.CanResendAt.Should().Be(challenge.CanResendAt);
+        challenge.EmailNormalized.Should().Be("BUYER-OTP@HIVESPACE.LOCAL");
+        challenge.Purpose.Should().Be(OtpChallengePurpose.SignIn);
+        publisher.PublishedOtpRequests.Should().ContainSingle();
+        publisher.PublishedOtpRequests.Single().RecipientEmail.Should().Be("buyer-otp@hivespace.local");
+        publisher.PublishedOtpRequests.Single().OtpCode.Should().Be(challenge.Code);
+        publisher.PublishedOtpRequests.Single().Purpose.Should().Be(nameof(OtpChallengePurpose.SignIn));
+    }
+
+    [Fact]
+    public async Task Handle_UnknownLockedInactiveOrAdminAccount_ReturnsGenericResponseWithoutUsableChallenge()
+    {
+        var cases = new[]
+        {
+            (Email: "unknown-otp@hivespace.local", Role: (string?)null, Status: UserStatus.Active, Confirmed: true, Lockout: false, SeedUser: false),
+            (Email: "locked-otp@hivespace.local", Role: "Buyer", Status: UserStatus.Active, Confirmed: true, Lockout: true, SeedUser: true),
+            (Email: "inactive-otp@hivespace.local", Role: "Buyer", Status: UserStatus.Inactive, Confirmed: true, Lockout: false, SeedUser: true),
+            (Email: "admin-otp@hivespace.local", Role: "Admin", Status: UserStatus.Active, Confirmed: true, Lockout: false, SeedUser: true)
+        };
+
+        foreach (var testCase in cases)
+        {
+            await using var dbContext = CreateDbContext();
+            var userManager = CreateUserManager(dbContext);
+
+            if (testCase.SeedUser)
+            {
+                var user = CreateUser(testCase.Email, testCase.Role, testCase.Status, testCase.Confirmed);
+                if (testCase.Lockout)
+                {
+                    user.LockoutEnabled = true;
+                    user.LockoutEnd = DateTimeOffset.UtcNow.AddMinutes(5);
+                }
+
+                dbContext.Users.Add(user);
+                await dbContext.SaveChangesAsync();
+            }
+
+            var publisher = new RecordingIdentityEventPublisher();
+            var handler = new RequestOtpSignInCommandHandler(
+                userManager,
+                new OtpChallengeRepository(dbContext),
+                publisher,
+                CreateConfiguration());
+
+            var response = await handler.Handle(new RequestOtpSignInCommand(testCase.Email), CancellationToken.None);
+
+            response.ChallengeToken.Should().NotBeNullOrWhiteSpace();
+            response.ExpiresAt.Should().BeAfter(DateTimeOffset.UtcNow.AddMinutes(9));
+            response.CanResendAt.Should().BeAfter(DateTimeOffset.UtcNow);
+            (await dbContext.Set<OtpChallenge>().CountAsync()).Should().Be(0);
+            publisher.PublishedOtpRequests.Should().BeEmpty();
+        }
+    }
+
+    [Fact]
+    public async Task Handle_RequestDuringCooldown_ReturnsExistingResendTimingWithoutIssuingNewCode()
+    {
+        await using var dbContext = CreateDbContext();
+        var userManager = CreateUserManager(dbContext);
+        var user = CreateUser("cooldown-otp@hivespace.local", "Buyer", UserStatus.Active, emailConfirmed: true);
+        var existingChallenge = OtpChallenge.Create(
+            "COOLDOWN-OTP@HIVESPACE.LOCAL",
+            OtpChallengePurpose.SignIn,
+            Guid.NewGuid().ToString("N"),
+            "654321",
+            DateTimeOffset.UtcNow.AddMinutes(10),
+            DateTimeOffset.UtcNow.AddSeconds(30));
+
+        dbContext.Users.Add(user);
+        dbContext.Set<OtpChallenge>().Add(existingChallenge);
+        await dbContext.SaveChangesAsync();
+
+        var publisher = new RecordingIdentityEventPublisher();
+        var handler = new RequestOtpSignInCommandHandler(
+            userManager,
+            new OtpChallengeRepository(dbContext),
+            publisher,
+            CreateConfiguration());
+
+        var response = await handler.Handle(
+            new RequestOtpSignInCommand("cooldown-otp@hivespace.local"),
+            CancellationToken.None);
+
+        response.ChallengeToken.Should().Be(existingChallenge.ChallengeToken);
+        response.ExpiresAt.Should().Be(existingChallenge.ExpiresAt);
+        response.CanResendAt.Should().Be(existingChallenge.CanResendAt);
+        (await dbContext.Set<OtpChallenge>().CountAsync()).Should().Be(1);
+        publisher.PublishedOtpRequests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_RequestAfterCooldown_InvalidatesPreviousChallengeAndIssuesNewCode()
+    {
+        await using var dbContext = CreateDbContext();
+        var userManager = CreateUserManager(dbContext);
+        var user = CreateUser("resend-otp@hivespace.local", "Buyer", UserStatus.Active, emailConfirmed: true);
+        var existingChallenge = OtpChallenge.Create(
+            "RESEND-OTP@HIVESPACE.LOCAL",
+            OtpChallengePurpose.SignIn,
+            Guid.NewGuid().ToString("N"),
+            "111111",
+            DateTimeOffset.UtcNow.AddMinutes(5),
+            DateTimeOffset.UtcNow.AddSeconds(-5));
+
+        dbContext.Users.Add(user);
+        dbContext.Set<OtpChallenge>().Add(existingChallenge);
+        await dbContext.SaveChangesAsync();
+
+        var publisher = new RecordingIdentityEventPublisher();
+        var handler = new RequestOtpSignInCommandHandler(
+            userManager,
+            new OtpChallengeRepository(dbContext),
+            publisher,
+            CreateConfiguration());
+
+        var response = await handler.Handle(
+            new RequestOtpSignInCommand("resend-otp@hivespace.local"),
+            CancellationToken.None);
+
+        var challenges = await dbContext.Set<OtpChallenge>()
+            .OrderBy(x => x.CreatedAt)
+            .ToListAsync();
+
+        challenges.Should().HaveCount(2);
+        challenges[0].IsInvalidated.Should().BeTrue();
+        challenges[1].IsInvalidated.Should().BeFalse();
+        challenges[1].IsUsed.Should().BeFalse();
+        response.ChallengeToken.Should().Be(challenges[1].ChallengeToken);
+        response.ChallengeToken.Should().NotBe(existingChallenge.ChallengeToken);
+        response.ExpiresAt.Should().Be(challenges[1].ExpiresAt);
+        response.CanResendAt.Should().Be(challenges[1].CanResendAt);
+        publisher.PublishedOtpRequests.Should().ContainSingle();
+        publisher.PublishedOtpRequests.Single().OtpCode.Should().Be(challenges[1].Code);
+    }
+
+    private static IdentityDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<IdentityDbContext>()
+            .UseInMemoryDatabase($"identity-otp-tests-{Guid.NewGuid()}")
+            .Options;
+
+        return new IdentityDbContext(options);
+    }
+
+    private static UserManager<ApplicationUser> CreateUserManager(IdentityDbContext dbContext)
+    {
+        var options = new IdentityOptions();
+        options.Lockout.AllowedForNewUsers = true;
+
+        var store = new Microsoft.AspNetCore.Identity.EntityFrameworkCore.UserStore<ApplicationUser, IdentityRole<Guid>, IdentityDbContext, Guid>(dbContext);
+        return new UserManager<ApplicationUser>(
+            store,
+            Options.Create(options),
+            new PasswordHasher<ApplicationUser>(),
+            Array.Empty<IUserValidator<ApplicationUser>>(),
+            Array.Empty<IPasswordValidator<ApplicationUser>>(),
+            new UpperInvariantLookupNormalizer(),
+            new IdentityErrorDescriber(),
+            new ServiceCollection().BuildServiceProvider(),
+            NullLogger<UserManager<ApplicationUser>>.Instance);
+    }
+
+    private static IConfiguration CreateConfiguration()
+        => new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Otp:CodeLengthDigits"] = "6",
+                ["Otp:ExpiryMinutes"] = "10",
+                ["Otp:CooldownSeconds"] = "60"
+            })
+            .Build();
+
+    private static ApplicationUser CreateUser(string email, string? roleName, UserStatus status, bool emailConfirmed)
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            Email = email,
+            NormalizedEmail = email.ToUpperInvariant(),
+            UserName = email,
+            NormalizedUserName = email.ToUpperInvariant(),
+            RoleName = roleName,
+            Status = status,
+            EmailConfirmed = emailConfirmed,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+    private sealed class RecordingIdentityEventPublisher : IIdentityEventPublisher
+    {
+        public List<UserOtpChallengeRequestedIntegrationEvent> PublishedOtpRequests { get; } = [];
+
+        public Task PublishIdentityUserReadyAsync(ApplicationUser user, string? fullName, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task PublishEmailVerificationRequestedAsync(
+            ApplicationUser user,
+            string verificationLink,
+            DateTime expiresAt,
+            HiveSpace.Domain.Shared.Enumerations.Culture locale,
+            CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task PublishEmailVerifiedAsync(
+            ApplicationUser user,
+            HiveSpace.Domain.Shared.Enumerations.Culture locale,
+            CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task PublishOtpChallengeRequestedAsync(
+            ApplicationUser user,
+            string otpCode,
+            DateTimeOffset expiresAt,
+            string purpose,
+            CancellationToken cancellationToken = default)
+        {
+            PublishedOtpRequests.Add(new UserOtpChallengeRequestedIntegrationEvent
+            {
+                RecipientEmail = user.Email!,
+                OtpCode = otpCode,
+                ExpiresAt = expiresAt,
+                Purpose = purpose
+            });
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/HiveSpace.IdentityService.Tests/Application/Session/RequestOtpSignInCommandHandlerTests.cs
+++ b/tests/HiveSpace.IdentityService.Tests/Application/Session/RequestOtpSignInCommandHandlerTests.cs
@@ -57,7 +57,8 @@ public class RequestOtpSignInCommandHandlerTests
             (Email: "unknown-otp@hivespace.local", Role: (string?)null, Status: UserStatus.Active, Confirmed: true, Lockout: false, SeedUser: false),
             (Email: "locked-otp@hivespace.local", Role: "Buyer", Status: UserStatus.Active, Confirmed: true, Lockout: true, SeedUser: true),
             (Email: "inactive-otp@hivespace.local", Role: "Buyer", Status: UserStatus.Inactive, Confirmed: true, Lockout: false, SeedUser: true),
-            (Email: "admin-otp@hivespace.local", Role: "Admin", Status: UserStatus.Active, Confirmed: true, Lockout: false, SeedUser: true)
+            (Email: "admin-otp@hivespace.local", Role: "Admin", Status: UserStatus.Active, Confirmed: true, Lockout: false, SeedUser: true),
+            (Email: "system-admin-otp@hivespace.local", Role: "SystemAdmin", Status: UserStatus.Active, Confirmed: true, Lockout: false, SeedUser: true)
         };
 
         foreach (var testCase in cases)
@@ -176,6 +177,31 @@ public class RequestOtpSignInCommandHandlerTests
         publisher.PublishedOtpRequests.Single().OtpCode.Should().Be(challenges[1].Code);
     }
 
+    [Fact]
+    public async Task Handle_GeneratesSixDigitCode_WhenConfigurationContainsDifferentLength()
+    {
+        await using var dbContext = CreateDbContext();
+        var userManager = CreateUserManager(dbContext);
+        var user = CreateUser("fixed-length-otp@hivespace.local", "Buyer", UserStatus.Active, emailConfirmed: true);
+        dbContext.Users.Add(user);
+        await dbContext.SaveChangesAsync();
+
+        var publisher = new RecordingIdentityEventPublisher();
+        var handler = new RequestOtpSignInCommandHandler(
+            userManager,
+            new OtpChallengeRepository(dbContext),
+            publisher,
+            CreateConfiguration(codeLengthDigits: 8));
+
+        await handler.Handle(
+            new RequestOtpSignInCommand("fixed-length-otp@hivespace.local"),
+            CancellationToken.None);
+
+        var challenge = await dbContext.Set<OtpChallenge>().SingleAsync();
+        challenge.Code.Should().MatchRegex(@"^\d{6}$");
+        publisher.PublishedOtpRequests.Single().OtpCode.Should().Be(challenge.Code);
+    }
+
     private static IdentityDbContext CreateDbContext()
     {
         var options = new DbContextOptionsBuilder<IdentityDbContext>()
@@ -203,11 +229,11 @@ public class RequestOtpSignInCommandHandlerTests
             NullLogger<UserManager<ApplicationUser>>.Instance);
     }
 
-    private static IConfiguration CreateConfiguration()
+    private static IConfiguration CreateConfiguration(int codeLengthDigits = 6)
         => new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Otp:CodeLengthDigits"] = "6",
+                ["Otp:CodeLengthDigits"] = codeLengthDigits.ToString(),
                 ["Otp:ExpiryMinutes"] = "10",
                 ["Otp:CooldownSeconds"] = "60"
             })

--- a/tests/HiveSpace.IdentityService.Tests/Application/Session/VerifyOtpSignInCommandHandlerTests.cs
+++ b/tests/HiveSpace.IdentityService.Tests/Application/Session/VerifyOtpSignInCommandHandlerTests.cs
@@ -177,6 +177,42 @@ public class VerifyOtpSignInCommandHandlerTests
         ex.Which.ErrorCodeList.Single().ErrorCode.Code.Should().Be("IDN6020");
     }
 
+    [Fact]
+    public async Task Handle_UserNoLongerEligibleForOtp_InvalidatesChallengeAndDoesNotIssueSession()
+    {
+        await using var dbContext = CreateDbContext();
+        var userManager = CreateUserManager(dbContext);
+        var user = CreateUser("role-changed-otp@hivespace.local", "Admin", UserStatus.Active, emailConfirmed: true);
+        var challenge = OtpChallenge.Create(
+            "ROLE-CHANGED-OTP@HIVESPACE.LOCAL",
+            OtpChallengePurpose.SignIn,
+            Guid.NewGuid().ToString("N"),
+            "123456",
+            DateTimeOffset.UtcNow.AddMinutes(10),
+            DateTimeOffset.UtcNow.AddSeconds(60));
+
+        dbContext.Users.Add(user);
+        dbContext.OtpChallenges.Add(challenge);
+        await dbContext.SaveChangesAsync();
+
+        var issuer = new RecordingAccountSessionIssuer();
+        var handler = new VerifyOtpSignInCommandHandler(
+            userManager,
+            new OtpChallengeRepository(dbContext),
+            issuer,
+            CreateConfiguration());
+
+        var act = () => handler.Handle(
+            new VerifyOtpSignInCommand(challenge.ChallengeToken, "123456", "buyer", null),
+            CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<UnauthorizedException>();
+        ex.Which.ErrorCodeList.Single().ErrorCode.Code.Should().Be("IDN6020");
+        challenge.IsInvalidated.Should().BeTrue();
+        challenge.IsUsed.Should().BeFalse();
+        issuer.Issued.Should().BeFalse();
+    }
+
     private static IdentityDbContext CreateDbContext()
     {
         var options = new DbContextOptionsBuilder<IdentityDbContext>()

--- a/tests/HiveSpace.IdentityService.Tests/Application/Session/VerifyOtpSignInCommandHandlerTests.cs
+++ b/tests/HiveSpace.IdentityService.Tests/Application/Session/VerifyOtpSignInCommandHandlerTests.cs
@@ -1,0 +1,278 @@
+using FluentAssertions;
+using HiveSpace.Core.Exceptions;
+using HiveSpace.IdentityService.Core.DomainModels;
+using HiveSpace.IdentityService.Core.Features.AccountSessions.Commands.VerifyOtpSignIn;
+using HiveSpace.IdentityService.Core.Features.AccountSessions.Dtos;
+using HiveSpace.IdentityService.Core.Interfaces.Services;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+using HiveSpace.IdentityService.Core.Persistence;
+using HiveSpace.IdentityService.Core.Persistence.Repositories;
+
+namespace HiveSpace.IdentityService.Tests.Application.Session;
+
+public class VerifyOtpSignInCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_ValidChallengeTokenAndCode_MarksChallengeUsedAndIssuesSession()
+    {
+        await using var dbContext = CreateDbContext();
+        var userManager = CreateUserManager(dbContext);
+        var user = CreateUser("verify-otp@hivespace.local", "Buyer", UserStatus.Active, emailConfirmed: true);
+        var challenge = OtpChallenge.Create(
+            "VERIFY-OTP@HIVESPACE.LOCAL",
+            OtpChallengePurpose.SignIn,
+            Guid.NewGuid().ToString("N"),
+            "123456",
+            DateTimeOffset.UtcNow.AddMinutes(10),
+            DateTimeOffset.UtcNow.AddSeconds(60));
+
+        dbContext.Users.Add(user);
+        dbContext.OtpChallenges.Add(challenge);
+        await dbContext.SaveChangesAsync();
+
+        var issuer = new RecordingAccountSessionIssuer();
+        var handler = new VerifyOtpSignInCommandHandler(
+            userManager,
+            new OtpChallengeRepository(dbContext),
+            issuer,
+            CreateConfiguration());
+
+        var response = await handler.Handle(
+            new VerifyOtpSignInCommand(challenge.ChallengeToken, "123456", "buyer", "/orders"),
+            CancellationToken.None);
+
+        response.RedirectUrl.Should().Be("/orders");
+        challenge.IsUsed.Should().BeTrue();
+        challenge.IsInvalidated.Should().BeFalse();
+        challenge.AttemptCount.Should().Be(0);
+        issuer.Issued.Should().BeTrue();
+        issuer.App.Should().Be("buyer");
+        issuer.ReturnUrl.Should().Be("/orders");
+    }
+
+    [Fact]
+    public async Task Handle_ExpiredUsedInvalidatedOrMissingChallenge_ReturnsInvalidOrExpiredCode()
+    {
+        var cases = new[]
+        {
+            "missing",
+            "expired",
+            "used",
+            "invalidated"
+        };
+
+        foreach (var scenario in cases)
+        {
+            await using var dbContext = CreateDbContext();
+            var userManager = CreateUserManager(dbContext);
+            var user = CreateUser($"otp-{scenario}@hivespace.local", "Buyer", UserStatus.Active, emailConfirmed: true);
+            dbContext.Users.Add(user);
+
+            var challenge = OtpChallenge.Create(
+                user.NormalizedEmail!,
+                OtpChallengePurpose.SignIn,
+                Guid.NewGuid().ToString("N"),
+                "111111",
+                scenario == "expired" ? DateTimeOffset.UtcNow.AddMinutes(-1) : DateTimeOffset.UtcNow.AddMinutes(10),
+                DateTimeOffset.UtcNow.AddSeconds(60));
+
+            if (scenario == "used")
+                challenge.MarkUsed();
+
+            if (scenario == "invalidated")
+                challenge.Invalidate();
+
+            if (scenario != "missing")
+                dbContext.OtpChallenges.Add(challenge);
+
+            await dbContext.SaveChangesAsync();
+
+            var handler = new VerifyOtpSignInCommandHandler(
+                userManager,
+                new OtpChallengeRepository(dbContext),
+                new RecordingAccountSessionIssuer(),
+                CreateConfiguration());
+
+            var act = () => handler.Handle(
+                new VerifyOtpSignInCommand(challenge.ChallengeToken, "111111", "buyer", null),
+                CancellationToken.None);
+
+            var ex = await act.Should().ThrowAsync<UnauthorizedException>();
+            ex.Which.ErrorCodeList.Single().ErrorCode.Code.Should().Be("IDN6020");
+        }
+    }
+
+    [Fact]
+    public async Task Handle_MaxAttemptsReached_InvalidatesChallengeAndReturnsMaxAttemptsExceeded()
+    {
+        await using var dbContext = CreateDbContext();
+        var userManager = CreateUserManager(dbContext);
+        var user = CreateUser("max-attempts@hivespace.local", "Buyer", UserStatus.Active, emailConfirmed: true);
+        var challenge = OtpChallenge.Create(
+            "MAX-ATTEMPTS@HIVESPACE.LOCAL",
+            OtpChallengePurpose.SignIn,
+            Guid.NewGuid().ToString("N"),
+            "123456",
+            DateTimeOffset.UtcNow.AddMinutes(10),
+            DateTimeOffset.UtcNow.AddSeconds(60));
+
+        for (var i = 0; i < 4; i++)
+            challenge.IncrementAttempt();
+
+        dbContext.Users.Add(user);
+        dbContext.OtpChallenges.Add(challenge);
+        await dbContext.SaveChangesAsync();
+
+        var handler = new VerifyOtpSignInCommandHandler(
+            userManager,
+            new OtpChallengeRepository(dbContext),
+            new RecordingAccountSessionIssuer(),
+            CreateConfiguration());
+
+        var act = () => handler.Handle(
+            new VerifyOtpSignInCommand(challenge.ChallengeToken, "000000", "buyer", null),
+            CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<UnauthorizedException>();
+        ex.Which.ErrorCodeList.Single().ErrorCode.Code.Should().Be("IDN6021");
+        challenge.IsInvalidated.Should().BeTrue();
+        challenge.AttemptCount.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task Handle_NonSignInPurpose_RejectsVerification()
+    {
+        await using var dbContext = CreateDbContext();
+        var userManager = CreateUserManager(dbContext);
+        var user = CreateUser("wrong-purpose@hivespace.local", "Buyer", UserStatus.Active, emailConfirmed: true);
+        var challenge = OtpChallenge.Create(
+            "WRONG-PURPOSE@HIVESPACE.LOCAL",
+            (OtpChallengePurpose)99,
+            Guid.NewGuid().ToString("N"),
+            "123456",
+            DateTimeOffset.UtcNow.AddMinutes(10),
+            DateTimeOffset.UtcNow.AddSeconds(60));
+
+        dbContext.Users.Add(user);
+        dbContext.OtpChallenges.Add(challenge);
+        await dbContext.SaveChangesAsync();
+
+        var handler = new VerifyOtpSignInCommandHandler(
+            userManager,
+            new OtpChallengeRepository(dbContext),
+            new RecordingAccountSessionIssuer(),
+            CreateConfiguration());
+
+        var act = () => handler.Handle(
+            new VerifyOtpSignInCommand(challenge.ChallengeToken, "123456", "buyer", null),
+            CancellationToken.None);
+
+        var ex = await act.Should().ThrowAsync<UnauthorizedException>();
+        ex.Which.ErrorCodeList.Single().ErrorCode.Code.Should().Be("IDN6020");
+    }
+
+    private static IdentityDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<IdentityDbContext>()
+            .UseInMemoryDatabase($"identity-otp-verify-tests-{Guid.NewGuid()}")
+            .Options;
+
+        return new IdentityDbContext(options);
+    }
+
+    private static UserManager<ApplicationUser> CreateUserManager(IdentityDbContext dbContext)
+    {
+        var options = new IdentityOptions();
+        options.Lockout.AllowedForNewUsers = true;
+
+        var store = new Microsoft.AspNetCore.Identity.EntityFrameworkCore.UserStore<ApplicationUser, IdentityRole<Guid>, IdentityDbContext, Guid>(dbContext);
+        return new UserManager<ApplicationUser>(
+            store,
+            Options.Create(options),
+            new PasswordHasher<ApplicationUser>(),
+            Array.Empty<IUserValidator<ApplicationUser>>(),
+            Array.Empty<IPasswordValidator<ApplicationUser>>(),
+            new UpperInvariantLookupNormalizer(),
+            new IdentityErrorDescriber(),
+            new ServiceCollection().BuildServiceProvider(),
+            NullLogger<UserManager<ApplicationUser>>.Instance);
+    }
+
+    private static IConfiguration CreateConfiguration()
+        => new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Otp:MaxAttempts"] = "5"
+            })
+            .Build();
+
+    private static ApplicationUser CreateUser(string email, string? roleName, UserStatus status, bool emailConfirmed)
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            Email = email,
+            NormalizedEmail = email.ToUpperInvariant(),
+            UserName = email,
+            NormalizedUserName = email.ToUpperInvariant(),
+            RoleName = roleName,
+            Status = status,
+            EmailConfirmed = emailConfirmed,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+
+    private sealed class RecordingAccountSessionIssuer : IAccountSessionIssuer
+    {
+        public bool Issued { get; private set; }
+        public string? App { get; private set; }
+        public string? ReturnUrl { get; private set; }
+
+        public Task<IReadOnlySet<string>> ValidateCanIssueAsync(
+            ApplicationUser user,
+            string app,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult<IReadOnlySet<string>>(new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                user.RoleName ?? "Buyer"
+            });
+
+        public Task<SessionResponse> IssueAsync(
+            ApplicationUser user,
+            string app,
+            string? returnUrl,
+            bool updateLastLogin,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task<SessionResponse> IssueAsync(
+            ApplicationUser user,
+            string app,
+            string? returnUrl,
+            bool updateLastLogin,
+            IReadOnlyCollection<string> roles,
+            CancellationToken cancellationToken = default)
+        {
+            Issued = true;
+            App = app;
+            ReturnUrl = returnUrl;
+
+            return Task.FromResult(new SessionResponse(
+                new SessionUser(
+                    user.Id,
+                    user.Email ?? string.Empty,
+                    user.UserName,
+                    roles.ToArray(),
+                    user.EmailConfirmed,
+                    user.Status.ToString()),
+                DateTimeOffset.UtcNow.AddMinutes(15),
+                DateTimeOffset.UtcNow.AddDays(30),
+                "csrf-token",
+                returnUrl));
+        }
+    }
+}

--- a/tests/HiveSpace.IdentityService.Tests/Domain/OtpChallengeTests.cs
+++ b/tests/HiveSpace.IdentityService.Tests/Domain/OtpChallengeTests.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using HiveSpace.IdentityService.Core.DomainModels;
+using Xunit;
+
+namespace HiveSpace.IdentityService.Tests.Domain;
+
+public class OtpChallengeTests
+{
+    [Fact]
+    public void Create_SetsInitialState()
+    {
+        var expiresAt = DateTimeOffset.UtcNow.AddMinutes(10);
+        var canResendAt = DateTimeOffset.UtcNow.AddMinutes(1);
+
+        var challenge = OtpChallenge.Create(
+            "BUYER@HIVESPACE.LOCAL",
+            OtpChallengePurpose.SignIn,
+            "token-123",
+            "654321",
+            expiresAt,
+            canResendAt);
+
+        challenge.Id.Value.Should().NotBeEmpty();
+        challenge.EmailNormalized.Should().Be("BUYER@HIVESPACE.LOCAL");
+        challenge.Purpose.Should().Be(OtpChallengePurpose.SignIn);
+        challenge.ChallengeToken.Should().Be("token-123");
+        challenge.Code.Should().Be("654321");
+        challenge.ExpiresAt.Should().Be(expiresAt);
+        challenge.CanResendAt.Should().Be(canResendAt);
+        challenge.AttemptCount.Should().Be(0);
+        challenge.IsUsed.Should().BeFalse();
+        challenge.IsInvalidated.Should().BeFalse();
+        challenge.IsActiveAt(DateTimeOffset.UtcNow).Should().BeTrue();
+    }
+
+    [Fact]
+    public void LifecycleMethods_UpdateChallengeState()
+    {
+        var challenge = OtpChallenge.Create(
+            "BUYER@HIVESPACE.LOCAL",
+            OtpChallengePurpose.SignIn,
+            "token-456",
+            "123456",
+            DateTimeOffset.UtcNow.AddMinutes(10),
+            DateTimeOffset.UtcNow.AddMinutes(1));
+
+        challenge.IncrementAttempt();
+        challenge.IncrementAttempt();
+        challenge.AttemptCount.Should().Be(2);
+
+        challenge.MarkUsed();
+        challenge.IsUsed.Should().BeTrue();
+        challenge.IsActiveAt(DateTimeOffset.UtcNow).Should().BeFalse();
+
+        var invalidated = OtpChallenge.Create(
+            "SELLER@HIVESPACE.LOCAL",
+            OtpChallengePurpose.SignIn,
+            "token-789",
+            "999999",
+            DateTimeOffset.UtcNow.AddMinutes(10),
+            DateTimeOffset.UtcNow.AddMinutes(1));
+
+        invalidated.Invalidate();
+        invalidated.IsInvalidated.Should().BeTrue();
+        invalidated.IsActiveAt(DateTimeOffset.UtcNow).Should().BeFalse();
+
+        var expired = OtpChallenge.Create(
+            "EXPIRED@HIVESPACE.LOCAL",
+            OtpChallengePurpose.SignIn,
+            "token-expired",
+            "111111",
+            DateTimeOffset.UtcNow.AddSeconds(-1),
+            DateTimeOffset.UtcNow.AddMinutes(-1));
+
+        expired.IsActiveAt(DateTimeOffset.UtcNow).Should().BeFalse();
+    }
+}

--- a/tests/HiveSpace.NotificationService.Tests/Consumers/OtpChallengeRequestedConsumerTests.cs
+++ b/tests/HiveSpace.NotificationService.Tests/Consumers/OtpChallengeRequestedConsumerTests.cs
@@ -1,0 +1,88 @@
+using FluentAssertions;
+using HiveSpace.Infrastructure.Messaging.Shared.Events.Users;
+using HiveSpace.NotificationService.Api.Consumers;
+using HiveSpace.NotificationService.Core.Dispatch.Models;
+using HiveSpace.NotificationService.Core.Interfaces;
+using HiveSpace.Domain.Shared.Exceptions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace HiveSpace.NotificationService.Tests.Consumers;
+
+public class OtpChallengeRequestedConsumerTests
+{
+    [Fact]
+    public async Task Consume_SignInPurpose_SendsOtpEmail()
+    {
+        var pipeline = new RecordingDispatchPipeline();
+        var consumer = new OtpChallengeRequestedConsumer(
+            pipeline,
+            NullLogger<OtpChallengeRequestedConsumer>.Instance);
+
+        await consumer.ConsumeMessageAsync(new UserOtpChallengeRequestedIntegrationEvent
+        {
+            RecipientEmail = "otp@hivespace.local",
+            OtpCode = "123456",
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(10),
+            Purpose = "SignIn"
+        });
+
+        pipeline.Requests.Should().ContainSingle();
+        pipeline.Requests.Single().EventType.Should().Be("user.otp.signin");
+        pipeline.Requests.Single().IsTransactional.Should().BeTrue();
+        pipeline.Requests.Single().TemplateData["_recipientEmail"].Should().Be("otp@hivespace.local");
+        pipeline.Requests.Single().TemplateData["otpCode"].Should().Be("123456");
+    }
+
+    [Fact]
+    public async Task Consume_DuplicateMessage_RemainsIdempotent()
+    {
+        var pipeline = new RecordingDispatchPipeline();
+        var consumer = new OtpChallengeRequestedConsumer(
+            pipeline,
+            NullLogger<OtpChallengeRequestedConsumer>.Instance);
+        var message = new UserOtpChallengeRequestedIntegrationEvent
+        {
+            RecipientEmail = "dup-otp@hivespace.local",
+            OtpCode = "123456",
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(10),
+            Purpose = "SignIn"
+        };
+
+        await consumer.ConsumeMessageAsync(message);
+        await consumer.ConsumeMessageAsync(message);
+
+        pipeline.Requests.Should().HaveCount(2);
+        pipeline.Requests[0].IdempotencyKey.Should().Be(pipeline.Requests[1].IdempotencyKey);
+    }
+
+    [Fact]
+    public async Task Consume_UnknownPurpose_FailsObservably()
+    {
+        var consumer = new OtpChallengeRequestedConsumer(
+            new RecordingDispatchPipeline(),
+            NullLogger<OtpChallengeRequestedConsumer>.Instance);
+        var message = new UserOtpChallengeRequestedIntegrationEvent
+        {
+            RecipientEmail = "unsupported@hivespace.local",
+            OtpCode = "999999",
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(10),
+            Purpose = "PasswordReset"
+        };
+
+        var act = () => consumer.ConsumeMessageAsync(message);
+
+        await act.Should().ThrowAsync<InvalidFieldException>();
+    }
+
+    private sealed class RecordingDispatchPipeline : IDispatchPipeline
+    {
+        public List<NotificationRequest> Requests { get; } = [];
+
+        public Task DispatchAsync(NotificationRequest request, CancellationToken ct = default)
+        {
+            Requests.Add(request);
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
﻿## Summary
- add OTP sign-in request and verify endpoints, challenge persistence, and notification publishing for IdentityService
- add OTP cleanup, domain, repository, migration, and notification consumer coverage for the new sign-in flow
- block admin and system-admin OTP issuance, re-check OTP eligibility during verification, and keep OTP codes fixed at 6 digits

## Test plan
- [x] dotnet build
- [x] targeted IdentityService OTP request/verify tests
- [ ] Manual OTP sign-in smoke test across request and verify endpoints
